### PR TITLE
Add end-of-life warning

### DIFF
--- a/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
+++ b/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
@@ -59,7 +59,8 @@ public partial class DotNetUpgradeFinder(
                     out var channel,
                     out var sdkVersion,
                     out var releaseType,
-                    out var isEndOfLife)
+                    out var isEndOfLife,
+                    out var endOfLifeDate)
                 || isEndOfLife)
             {
                 if (!isEndOfLife)
@@ -73,6 +74,7 @@ public partial class DotNetUpgradeFinder(
             channels.Add(new()
             {
                 Channel = channel,
+                EndOfLife = endOfLifeDate,
                 ReleaseType = releaseType,
                 SdkVersion = sdkVersion,
             });
@@ -85,16 +87,32 @@ public partial class DotNetUpgradeFinder(
             [NotNullWhen(true)] out Version? channel,
             [NotNullWhen(true)] out NuGetVersion? sdkVersion,
             out DotNetReleaseType releaseType,
-            out bool isEndOfLife)
+            out bool isEndOfLife,
+            out DateOnly? endOfLife)
         {
             channel = null;
             sdkVersion = null;
             releaseType = default;
+            endOfLife = default;
 
             var channelString = GetString(element, "channel-version");
             var latestSdkVersion = GetString(element, "latest-sdk");
             var releaseTypeString = GetString(element, "release-type");
             var supportPhase = GetString(element, "support-phase");
+            var endOfLifeString = GetString(element, "eol-date");
+
+            if (endOfLifeString is { Length: > 0 })
+            {
+                if (DateOnly.TryParseExact(
+                        endOfLifeString,
+                        "yyyy-MM-dd",
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.None,
+                        out DateOnly eol))
+                {
+                    endOfLife = eol;
+                }
+            }
 
             isEndOfLife = supportPhase is "eol";
 

--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using MartinCostello.DotNetBumper.Upgrades;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Spectre.Console;
@@ -35,6 +36,8 @@ public static class ServiceCollectionExtensions
     {
         services.AddLogging(configureLogging);
         services.AddOptions<UpgradeOptions>();
+
+        services.TryAddSingleton(TimeProvider.System);
 
         services.AddSingleton(configuration)
                 .AddSingleton<IAnsiConsole>(console)

--- a/src/DotNetBumper.Core/UpgradeInfo.cs
+++ b/src/DotNetBumper.Core/UpgradeInfo.cs
@@ -24,4 +24,9 @@ public sealed class UpgradeInfo
     /// Gets the type of the .NET release.
     /// </summary>
     public required DotNetReleaseType ReleaseType { get; init; }
+
+    /// <summary>
+    /// Gets the end-of-time date of the .NET release channel, if known.
+    /// </summary>
+    public required DateOnly? EndOfLife { get; init; }
 }

--- a/tests/DotNetBumper.Tests/ProjectUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/ProjectUpgraderTests.cs
@@ -40,6 +40,7 @@ public class ProjectUpgraderTests(ITestOutputHelper outputHelper)
             fixture.Console,
             finder,
             [Substitute.For<IUpgrader>()],
+            TimeProvider.System,
             options,
             outputHelper.ToLogger<ProjectUpgrader>());
     }


### PR DESCRIPTION
- Warn if upgrading to a version of .NET whose support ends in less than 100 days.
- Prevent downgrading target frameworks.
