### PR TITLE
Add .vsconfig upgrader

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@
 
 ## Introduction
 
-A .NET Global Tool and GitHub Action re-usable workflow to upgrade projects to a newer version of .NET.
+A .NET Global Tool to upgrade projects to a newer version of .NET.
+
+> [!NOTE]
+> Upgrades are made on a best-effort basis. You should always review the
+> changes made by the tool and test any changes made to validate the upgrade.
 
 ## Building and Testing
 

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -85,7 +85,7 @@ public partial class ProjectUpgrader(
 
         bool hasChanges = false;
 
-        foreach (var upgrader in upgraders)
+        foreach (var upgrader in upgraders.OrderBy((p) => p.Priority))
         {
             hasChanges |= await upgrader.UpgradeAsync(upgrade, cancellationToken);
         }

--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IUpgrader, PackageVersionUpgrader>();
         services.AddSingleton<IUpgrader, ServerlessUpgrader>();
         services.AddSingleton<IUpgrader, TargetFrameworkUpgrader>();
+        services.AddSingleton<IUpgrader, VisualStudioComponentUpgrader>();
 
         services.AddHttpClient()
                 .ConfigureHttpClientDefaults((options) =>

--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -46,11 +46,9 @@ public static class ServiceCollectionExtensions
                 .AddSingleton<ProjectUpgrader>();
 
         services.AddSingleton<IUpgrader, GlobalJsonUpgrader>();
+        services.AddSingleton<IUpgrader, PackageVersionUpgrader>();
         services.AddSingleton<IUpgrader, ServerlessUpgrader>();
         services.AddSingleton<IUpgrader, TargetFrameworkUpgrader>();
-
-        // Packages need to be updated after the TFM so the packages relate to the update
-        services.AddSingleton<IUpgrader, PackageVersionUpgrader>();
 
         services.AddHttpClient()
                 .ConfigureHttpClientDefaults((options) =>

--- a/src/DotNetBumper.Core/Upgraders/IUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/IUpgrader.cs
@@ -9,6 +9,11 @@ namespace MartinCostello.DotNetBumper.Upgrades;
 public interface IUpgrader
 {
     /// <summary>
+    /// Gets the global priority of the upgrader.
+    /// </summary>
+    int Priority { get; }
+
+    /// <summary>
     /// Attempts to apply an upgrade to the project.
     /// </summary>
     /// <param name="upgrade">The version of .NET to upgrade to.</param>

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -14,6 +14,8 @@ internal sealed partial class PackageVersionUpgrader(
     IOptions<UpgradeOptions> options,
     ILogger<PackageVersionUpgrader> logger) : Upgrader(console, options, logger)
 {
+    public override int Priority => int.MaxValue; // Packages need to be updated after the TFM so the packages relate to the update
+
     protected override string Action => "Upgrading NuGet packages";
 
     protected override string InitialStatus => "Upgrade NuGet packages";

--- a/src/DotNetBumper.Core/Upgraders/Upgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/Upgrader.cs
@@ -12,6 +12,8 @@ internal abstract partial class Upgrader(
     IOptions<UpgradeOptions> options,
     ILogger logger) : IUpgrader
 {
+    public virtual int Priority => 0;
+
     protected IAnsiConsole Console => console;
 
     protected UpgradeOptions Options => options.Value;

--- a/src/DotNetBumper.Core/Upgraders/VisualStudioComponentUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/VisualStudioComponentUpgrader.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+
+namespace MartinCostello.DotNetBumper.Upgrades;
+
+internal sealed partial class VisualStudioComponentUpgrader(
+    IAnsiConsole console,
+    IOptions<UpgradeOptions> options,
+    ILogger<VisualStudioComponentUpgrader> logger) : FileUpgrader(console, options, logger)
+{
+    protected override string Action => "Upgrading Visual Studio configuration";
+
+    protected override string InitialStatus => "Update Visual Studio configuration";
+
+    protected override IReadOnlyList<string> Patterns => [".vsconfig"];
+
+    protected override async Task<bool> UpgradeCoreAsync(
+        UpgradeInfo upgrade,
+        IReadOnlyList<string> fileNames,
+        StatusContext context,
+        CancellationToken cancellationToken)
+    {
+        Log.UpgradingComponentConfiguration(logger);
+
+        bool filesChanged = false;
+
+        foreach (var path in fileNames)
+        {
+            var name = RelativeName(path);
+
+            context.Status = StatusMessage($"Parsing {name}...");
+
+            if (!TryEditConfiguration(path, upgrade.Channel, out var configuration))
+            {
+                continue;
+            }
+
+            context.Status = StatusMessage($"Updating {name}...");
+
+            await UpdateConfigurationAsync(path, configuration, cancellationToken);
+
+            filesChanged = true;
+        }
+
+        return filesChanged;
+    }
+
+    private static async Task UpdateConfigurationAsync(string path, JsonObject configuration, CancellationToken cancellationToken)
+    {
+        using var stream = File.OpenWrite(path);
+        using var writer = new Utf8JsonWriter(stream, new() { Indented = true });
+
+        configuration.WriteTo(writer);
+        await writer.FlushAsync(cancellationToken);
+
+        await stream.WriteAsync(Encoding.UTF8.GetBytes(Environment.NewLine), cancellationToken);
+    }
+
+    private bool TryEditConfiguration(string path, Version channel, [NotNullWhen(true)] out JsonObject? configuration)
+    {
+        configuration = null;
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            configuration = JsonNode.Parse(stream) as JsonObject;
+
+            if (configuration is null)
+            {
+                return false;
+            }
+        }
+        catch (JsonException ex)
+        {
+            Log.ParseConfigurationFailed(logger, path, ex);
+            return false;
+        }
+
+        if (!configuration.TryGetPropertyValue("components", out var components) ||
+            components is not JsonArray array)
+        {
+            return false;
+        }
+
+        const string ComponentPrefix = "Microsoft.NetCore.Component.Runtime.";
+
+        List<int> indexes = [];
+
+        for (int i = 0; i < array.Count; i++)
+        {
+            var item = array[i];
+
+            if (item is not JsonValue value ||
+                value.GetValueKind() != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            string id = value.GetValue<string>();
+
+            if (id.StartsWith(ComponentPrefix, StringComparison.Ordinal) &&
+                Version.TryParse(id[ComponentPrefix.Length..], out var version) &&
+                version < channel)
+            {
+                indexes.Add(i);
+            }
+        }
+
+        bool updated = false;
+        string component = $"{ComponentPrefix}{channel.ToString(2)}";
+
+        if (indexes.Count is 1)
+        {
+            // Replace the existing item
+            array[indexes[0]] = component;
+            updated = true;
+        }
+        else if (indexes.Count > 1)
+        {
+            // Add the new item after the last existing item
+            array.Insert(indexes[^1] + 1, component);
+            updated = true;
+        }
+
+        return updated;
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 1,
+            Level = LogLevel.Debug,
+            Message = "Upgrading Visual Studio component configuration.")]
+        public static partial void UpgradingComponentConfiguration(ILogger logger);
+
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Warning,
+            Message = "Unable to parse configuration file {FileName}.")]
+        public static partial void ParseConfigurationFailed(
+            ILogger logger,
+            string fileName,
+            Exception exception);
+    }
+}

--- a/src/DotNetBumper.Core/Upgraders/VisualStudioComponentUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/VisualStudioComponentUpgrader.cs
@@ -91,6 +91,7 @@ internal sealed partial class VisualStudioComponentUpgrader(
         }
 
         const string ComponentPrefix = "Microsoft.NetCore.Component.Runtime.";
+        string component = $"{ComponentPrefix}{channel.ToString(2)}";
 
         List<int> indexes = [];
 
@@ -106,6 +107,11 @@ internal sealed partial class VisualStudioComponentUpgrader(
 
             string id = value.GetValue<string>();
 
+            if (string.Equals(id, component, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
             if (id.StartsWith(ComponentPrefix, StringComparison.Ordinal) &&
                 Version.TryParse(id[ComponentPrefix.Length..], out var version) &&
                 version < channel)
@@ -115,7 +121,6 @@ internal sealed partial class VisualStudioComponentUpgrader(
         }
 
         bool updated = false;
-        string component = $"{ComponentPrefix}{channel.ToString(2)}";
 
         if (indexes.Count is 1)
         {

--- a/src/DotNetBumper/Bumper.cs
+++ b/src/DotNetBumper/Bumper.cs
@@ -29,13 +29,13 @@ internal partial class Bumper(ProjectUpgrader upgrader)
 
     [Option(
         "-t|--upgrade-type <TYPE>",
-        Description = "The type of upgrade to perform. Possible values for <TYPE> are LTS (default), Latest or Preview.",
+        Description = "The type of upgrade to perform.",
         ValueName = "TYPE")]
     public UpgradeType? UpgradeType { get; set; }
 
     [Option(
         "-test|--test",
-        Description = "Whether to test the upgrade by running dotnet test on completion. The default value is false.")]
+        Description = "Test the upgrade by running dotnet test on completion.")]
     public bool TestUpgrade { get; set; }
 
     public static async Task<int> RunAsync(

--- a/tests/DotNetBumper.Tests/BumperTestCase.cs
+++ b/tests/DotNetBumper.Tests/BumperTestCase.cs
@@ -11,6 +11,8 @@ public sealed class BumperTestCase(
     IList<string>? args = null,
     IDictionary<string, string>? packageReferences = null)
 {
+    private Version? _channel;
+
     public string SdkVersion { get; } = sdkVersion;
 
     public IList<string> TargetFrameworks { get; } = targetFrameworks ?? [];
@@ -18,6 +20,20 @@ public sealed class BumperTestCase(
     public IDictionary<string, string> PackageReferences { get; } = packageReferences ?? new Dictionary<string, string>(0);
 
     public IList<string> Arguments { get; } = args ?? [];
+
+    public Version Channel
+    {
+        get
+        {
+            if (_channel is null)
+            {
+                var sdkVersion = Version.Parse(SdkVersion);
+                _channel = new(sdkVersion.Major, sdkVersion.Minor);
+            }
+
+            return _channel;
+        }
+    }
 
     public override string ToString()
     {

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -57,22 +57,22 @@ internal sealed class Project : IDisposable
         return await AddFileAsync(path, solution);
     }
 
-    public async Task<string> AddVisualStudioConfigurationAsync(string path = ".vsconfig")
+    public async Task<string> AddVisualStudioConfigurationAsync(string channel = "6.0", string path = ".vsconfig")
     {
         var configuration =
-            """
-            {
-              "version": "1.0",
-              "components": [
-                "Component.GitHub.VisualStudio",
-                "Microsoft.NetCore.Component.Runtime.6.0",
-                "Microsoft.NetCore.Component.SDK",
-                "Microsoft.VisualStudio.Component.CoreEditor",
-                "Microsoft.VisualStudio.Component.Git",
-                "Microsoft.VisualStudio.Workload.CoreEditor"
-              ]
-            }
-            """;
+            $$"""
+              {
+                "version": "1.0",
+                "components": [
+                  "Component.GitHub.VisualStudio",
+                  "Microsoft.NetCore.Component.Runtime.{{channel}}",
+                  "Microsoft.NetCore.Component.SDK",
+                  "Microsoft.VisualStudio.Component.CoreEditor",
+                  "Microsoft.VisualStudio.Component.Git",
+                  "Microsoft.VisualStudio.Workload.CoreEditor"
+                ]
+              }
+              """;
 
         return await AddFileAsync(path, configuration);
     }

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -36,10 +36,10 @@ internal sealed class Project : IDisposable
     public async Task<string> GetFileAsync(string path)
         => await File.ReadAllTextAsync(GetFilePath(path));
 
-    public async Task<string> AddGlobalJsonAsync(string sdkVersion)
+    public async Task<string> AddGlobalJsonAsync(string sdkVersion, string path = "global.json")
     {
         var globalJson = CreateGlobalJson(sdkVersion);
-        return await AddFileAsync("global.json", globalJson);
+        return await AddFileAsync(path, globalJson);
     }
 
     public async Task<string> AddProjectAsync(
@@ -55,6 +55,26 @@ internal sealed class Project : IDisposable
     {
         var solution = CreateSolution();
         return await AddFileAsync(path, solution);
+    }
+
+    public async Task<string> AddVisualStudioConfigurationAsync(string path = ".vsconfig")
+    {
+        var configuration =
+            """
+            {
+              "version": "1.0",
+              "components": [
+                "Component.GitHub.VisualStudio",
+                "Microsoft.NetCore.Component.Runtime.6.0",
+                "Microsoft.NetCore.Component.SDK",
+                "Microsoft.VisualStudio.Component.CoreEditor",
+                "Microsoft.VisualStudio.Component.Git",
+                "Microsoft.VisualStudio.Workload.CoreEditor"
+              ]
+            }
+            """;
+
+        return await AddFileAsync(path, configuration);
     }
 
     public void Dispose()

--- a/tests/DotNetBumper.Tests/Upgraders/VisualStudioComponentUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/VisualStudioComponentUpgraderTests.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using MartinCostello.DotNetBumper.Upgrades;
+using Microsoft.Extensions.Options;
+using Spectre.Console.Testing;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
+{
+    [Theory]
+    [InlineData("7.0")]
+    [InlineData("8.0")]
+    [InlineData("9.0")]
+    public async Task UpgradeAsync_Upgrades_Component_Configuration(string channel)
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string serverlessFile = await fixture.Project.AddVisualStudioConfigurationAsync("6.0");
+
+        var upgrade = new UpgradeInfo()
+        {
+            Channel = Version.Parse(channel),
+            EndOfLife = DateOnly.MaxValue,
+            ReleaseType = DotNetReleaseType.Lts,
+            SdkVersion = new($"{channel}.100"),
+        };
+
+        var options = Options.Create(new UpgradeOptions() { ProjectPath = fixture.Project.DirectoryName });
+        var logger = outputHelper.ToLogger<VisualStudioComponentUpgrader>();
+        var target = new VisualStudioComponentUpgrader(fixture.Console, options, logger);
+
+        // Act
+        bool actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBeTrue();
+
+        string actualContent = await File.ReadAllTextAsync(serverlessFile);
+        actualContent.ShouldContain($"\"Microsoft.NetCore.Component.Runtime.{channel}\"");
+
+        // Act
+        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_Upgrades_Component_Configuration_With_Multiple_Runtimes()
+    {
+        // Arrange
+        string content =
+            $$"""
+              {
+                "version": "1.0",
+                "components": [
+                  "Component.GitHub.VisualStudio",
+                  "Microsoft.NetCore.Component.Runtime.6.0",
+                  "Microsoft.NetCore.Component.Runtime.7.0",
+                  "Microsoft.NetCore.Component.SDK",
+                  "Microsoft.VisualStudio.Component.CoreEditor",
+                  "Microsoft.VisualStudio.Component.Git",
+                  "Microsoft.VisualStudio.Workload.CoreEditor"
+                ]
+              }
+              """;
+
+        string expectedContent =
+            $$"""
+              {
+                "version": "1.0",
+                "components": [
+                  "Component.GitHub.VisualStudio",
+                  "Microsoft.NetCore.Component.Runtime.6.0",
+                  "Microsoft.NetCore.Component.Runtime.7.0",
+                  "Microsoft.NetCore.Component.Runtime.8.0",
+                  "Microsoft.NetCore.Component.SDK",
+                  "Microsoft.VisualStudio.Component.CoreEditor",
+                  "Microsoft.VisualStudio.Component.Git",
+                  "Microsoft.VisualStudio.Workload.CoreEditor"
+                ]
+              }
+              """;
+
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string vsconfig = await fixture.Project.AddFileAsync(".vsconfig", content);
+
+        var upgrade = new UpgradeInfo()
+        {
+            Channel = new(8, 0),
+            EndOfLife = DateOnly.MaxValue,
+            ReleaseType = DotNetReleaseType.Lts,
+            SdkVersion = new("8.0.100"),
+        };
+
+        var options = Options.Create(new UpgradeOptions() { ProjectPath = fixture.Project.DirectoryName });
+        var logger = outputHelper.ToLogger<VisualStudioComponentUpgrader>();
+        var target = new VisualStudioComponentUpgrader(fixture.Console, options, logger);
+
+        // Act
+        bool actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBeTrue();
+
+        string actualContent = await File.ReadAllTextAsync(vsconfig);
+        actualContent.NormalizeLineEndings().TrimEnd().ShouldBe(expectedContent.NormalizeLineEndings().TrimEnd());
+
+        // Act
+        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("Not JSON")]
+    [InlineData("[]")]
+    [InlineData("[]]")]
+    [InlineData("\"value\"")]
+    [InlineData("{}")]
+    [InlineData("{\"foo\":\"bar\"}")]
+    [InlineData("{\"components\":{}}")]
+    public async Task UpgradeAsync_Handles_Invalid_Json(string content)
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string vsconfig = await fixture.Project.AddFileAsync(".vsconfig", content);
+
+        var upgrade = new UpgradeInfo()
+        {
+            Channel = new(8, 0),
+            EndOfLife = DateOnly.MaxValue,
+            ReleaseType = DotNetReleaseType.Lts,
+            SdkVersion = new("8.0.201"),
+        };
+
+        var options = Options.Create(new UpgradeOptions() { ProjectPath = fixture.Project.DirectoryName });
+        var logger = outputHelper.ToLogger<VisualStudioComponentUpgrader>();
+        var target = new VisualStudioComponentUpgrader(fixture.Console, options, logger);
+
+        // Act
+        bool actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actual.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
- Add upgrader to add/edit the Visual Studio component configuration in `.vsconfig`.
- Add a priority concept to the upgraders, rather than relying on the order of IoC registration.
