### PR TITLE
Add --warnings-as-errors switch

### DIFF
--- a/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
+++ b/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Versioning;
 
-namespace MartinCostello.DotNetBumper.Upgrades;
+namespace MartinCostello.DotNetBumper.Upgraders;
 
 /// <summary>
 /// A class that finds the latest version of .NET available to upgrade to.

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -142,7 +142,6 @@ public partial class ProjectUpgrader(
                             $"[teal]Running tests...[/]",
                             async (context) => await RunTestsAsync(projects, context, cancellationToken));
 
-                    // TODO Use Error if --warnings-as-errors
                     result = result.Max(testResult.Success ? UpgradeResult.Success : UpgradeResult.Warning);
 
                     console.WriteLine();
@@ -196,12 +195,14 @@ public partial class ProjectUpgrader(
             console.MarkupLine($"[aqua]{name}[/] upgrade to [purple].NET {upgrade.Channel}[/] [{color}]{description}[/]! {emoji}");
         }
 
-        // TODO Implement a --warnings-as-errors switch
+        const int Success = 0;
+        const int Error = 1;
+
         return result switch
         {
-            UpgradeResult.None or UpgradeResult.Success => 0,
-            UpgradeResult.Warning => 0,
-            _ => 1,
+            UpgradeResult.None or UpgradeResult.Success => Success,
+            UpgradeResult.Warning => options.Value.TreatWarningsAsErrors ? Error : Success,
+            _ => Error,
         };
     }
 

--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using MartinCostello.DotNetBumper.Upgrades;
+using MartinCostello.DotNetBumper.Upgraders;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/DotNetBumper.Core/UpgradeOptions.cs
+++ b/src/DotNetBumper.Core/UpgradeOptions.cs
@@ -30,4 +30,9 @@ public sealed class UpgradeOptions
     /// Gets or sets a value indicating whether to test the upgrade by running <c>dotnet test</c> on completion.
     /// </summary>
     public bool TestUpgrade { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to treat warnings as errors.
+    /// </summary>
+    public bool TreatWarningsAsErrors { get; set; }
 }

--- a/src/DotNetBumper.Core/Upgraders/FileUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/FileUpgrader.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Spectre.Console;
 
-namespace MartinCostello.DotNetBumper.Upgrades;
+namespace MartinCostello.DotNetBumper.Upgraders;
 
 internal abstract partial class FileUpgrader(
     IAnsiConsole console,
@@ -16,7 +16,7 @@ internal abstract partial class FileUpgrader(
 
     protected virtual SearchOption SearchOption => SearchOption.AllDirectories;
 
-    protected override async Task<bool> UpgradeCoreAsync(
+    protected override async Task<UpgradeResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,
         StatusContext context,
         CancellationToken cancellationToken)
@@ -30,13 +30,13 @@ internal abstract partial class FileUpgrader(
 
         if (fileNames.Count == 0)
         {
-            return false;
+            return UpgradeResult.None;
         }
 
         return await UpgradeCoreAsync(upgrade, fileNames, context, cancellationToken);
     }
 
-    protected abstract Task<bool> UpgradeCoreAsync(
+    protected abstract Task<UpgradeResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,
         IReadOnlyList<string> fileNames,
         StatusContext context,

--- a/src/DotNetBumper.Core/Upgraders/IUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/IUpgrader.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-namespace MartinCostello.DotNetBumper.Upgrades;
+namespace MartinCostello.DotNetBumper.Upgraders;
 
 /// <summary>
-/// Defines a method to upgrade a project in one or more ways to use a newer version of .NET.
+/// Defines a mechanism to upgrade a project in one or more ways to use a newer version of .NET.
 /// </summary>
 public interface IUpgrader
 {
@@ -19,9 +19,9 @@ public interface IUpgrader
     /// <param name="upgrade">The version of .NET to upgrade to.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
     /// <returns>
-    /// A <see cref="Task"/> representing the asynchronous operation to upgrade the project.
+    /// A <see cref="Task{UpgradeResult}"/> representing the result of the asynchronous operation to upgrade the project.
     /// </returns>
-    Task<bool> UpgradeAsync(
+    Task<UpgradeResult> UpgradeAsync(
         UpgradeInfo upgrade,
         CancellationToken cancellationToken);
 }

--- a/src/DotNetBumper.Core/Upgraders/UpgradeResult.cs
+++ b/src/DotNetBumper.Core/Upgraders/UpgradeResult.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+/// <summary>
+/// An enumeration representing the result of an upgrade.
+/// </summary>
+public enum UpgradeResult
+{
+    /// <summary>
+    /// Nothing was upgraded.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// One or more upgrades occurred.
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// One or more warnings occurred.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// One or more errors occurred.
+    /// </summary>
+    Error,
+}

--- a/src/DotNetBumper.Core/Upgraders/UpgradeResultExtensions.cs
+++ b/src/DotNetBumper.Core/Upgraders/UpgradeResultExtensions.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+internal static class UpgradeResultExtensions
+{
+    public static UpgradeResult Max(this UpgradeResult value, UpgradeResult other)
+        => (UpgradeResult)Math.Max((int)value, (int)other);
+}

--- a/src/DotNetBumper.Core/Upgraders/Upgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/Upgrader.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Spectre.Console;
 
-namespace MartinCostello.DotNetBumper.Upgrades;
+namespace MartinCostello.DotNetBumper.Upgraders;
 
 internal abstract partial class Upgrader(
     IAnsiConsole console,
@@ -28,7 +28,7 @@ internal abstract partial class Upgrader(
 
     protected virtual string StatusColor => "silver";
 
-    public virtual async Task<bool> UpgradeAsync(
+    public virtual async Task<UpgradeResult> UpgradeAsync(
         UpgradeInfo upgrade,
         CancellationToken cancellationToken)
     {
@@ -46,7 +46,7 @@ internal abstract partial class Upgrader(
     protected string StatusMessage(string message)
         => $"[{StatusColor}]{message}[/]";
 
-    protected abstract Task<bool> UpgradeCoreAsync(
+    protected abstract Task<UpgradeResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,
         StatusContext context,
         CancellationToken cancellationToken);

--- a/src/DotNetBumper.Core/Upgraders/VisualStudioComponentUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/VisualStudioComponentUpgrader.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Spectre.Console;
 
-namespace MartinCostello.DotNetBumper.Upgrades;
+namespace MartinCostello.DotNetBumper.Upgraders;
 
 internal sealed partial class VisualStudioComponentUpgrader(
     IAnsiConsole console,
@@ -22,7 +22,7 @@ internal sealed partial class VisualStudioComponentUpgrader(
 
     protected override IReadOnlyList<string> Patterns => [".vsconfig"];
 
-    protected override async Task<bool> UpgradeCoreAsync(
+    protected override async Task<UpgradeResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,
         IReadOnlyList<string> fileNames,
         StatusContext context,
@@ -30,7 +30,7 @@ internal sealed partial class VisualStudioComponentUpgrader(
     {
         Log.UpgradingComponentConfiguration(logger);
 
-        bool filesChanged = false;
+        UpgradeResult result = UpgradeResult.None;
 
         foreach (var path in fileNames)
         {
@@ -47,10 +47,10 @@ internal sealed partial class VisualStudioComponentUpgrader(
 
             await UpdateConfigurationAsync(path, configuration, cancellationToken);
 
-            filesChanged = true;
+            result = UpgradeResult.Success;
         }
 
-        return filesChanged;
+        return result;
     }
 
     private static async Task UpdateConfigurationAsync(string path, JsonObject configuration, CancellationToken cancellationToken)

--- a/src/DotNetBumper/Bumper.cs
+++ b/src/DotNetBumper/Bumper.cs
@@ -38,6 +38,11 @@ internal partial class Bumper(ProjectUpgrader upgrader)
         Description = "Test the upgrade by running dotnet test on completion.")]
     public bool TestUpgrade { get; set; }
 
+    [Option(
+        "-e|--warnings-as-errors",
+        Description = "Treat any warnings encountered during the upgrade as errors.")]
+    public bool WarningsAsErrors { get; set; }
+
     public static async Task<int> RunAsync(
         IAnsiConsole console,
         string[] args,

--- a/src/DotNetBumper/UpgradePostConfigureOptions.cs
+++ b/src/DotNetBumper/UpgradePostConfigureOptions.cs
@@ -15,6 +15,7 @@ internal sealed class UpgradePostConfigureOptions(IModelAccessor accessor) : IPo
         options.DotNetChannel ??= command.DotNetChannel;
         options.ProjectPath = command.ProjectPath ?? Environment.CurrentDirectory;
         options.TestUpgrade = command.TestUpgrade;
+        options.TreatWarningsAsErrors = command.WarningsAsErrors;
 
         if (command.UpgradeType is { } upgradeType)
         {

--- a/tests/DotNetBumper.Tests/ProjectUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/ProjectUpgraderTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using MartinCostello.DotNetBumper.Upgrades;
+using MartinCostello.DotNetBumper.Upgraders;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 

--- a/tests/DotNetBumper.Tests/Upgraders/ServerlessUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/ServerlessUpgraderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using MartinCostello.DotNetBumper.Upgrades;
 using Microsoft.Extensions.Options;
 
 namespace MartinCostello.DotNetBumper.Upgraders;
@@ -60,10 +59,10 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         var target = new ServerlessUpgrader(fixture.Console, options, logger);
 
         // Act
-        bool actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        UpgradeResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
 
         // Assert
-        actualUpdated.ShouldBeTrue();
+        actualUpdated.ShouldBe(UpgradeResult.Success);
 
         string expectedContent = string.Join(
             Environment.NewLine,
@@ -101,7 +100,7 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
 
         // Assert
-        actualUpdated.ShouldBeFalse();
+        actualUpdated.ShouldBe(UpgradeResult.None);
     }
 
     [Theory]
@@ -140,10 +139,10 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         var target = new ServerlessUpgrader(fixture.Console, options, logger);
 
         // Act
-        bool actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        UpgradeResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
 
         // Assert
-        actual.ShouldBeFalse();
+        actual.ShouldBe(UpgradeResult.None);
     }
 
     [Theory]
@@ -182,10 +181,10 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         var target = new ServerlessUpgrader(fixture.Console, options, logger);
 
         // Act
-        bool actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        UpgradeResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
 
         // Assert
-        actual.ShouldBeFalse();
+        actual.ShouldBe(UpgradeResult.None);
     }
 
     [Fact]
@@ -215,9 +214,9 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         var target = new ServerlessUpgrader(fixture.Console, options, logger);
 
         // Act
-        bool actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        UpgradeResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
 
         // Assert
-        actual.ShouldBeFalse();
+        actual.ShouldBe(UpgradeResult.Warning);
     }
 }

--- a/tests/DotNetBumper.Tests/Upgraders/VisualStudioComponentUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/VisualStudioComponentUpgraderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using MartinCostello.DotNetBumper.Upgrades;
 using Microsoft.Extensions.Options;
 using Spectre.Console.Testing;
 
@@ -33,10 +32,10 @@ public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
         var target = new VisualStudioComponentUpgrader(fixture.Console, options, logger);
 
         // Act
-        bool actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        UpgradeResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
 
         // Assert
-        actualUpdated.ShouldBeTrue();
+        actualUpdated.ShouldBe(UpgradeResult.Success);
 
         string actualContent = await File.ReadAllTextAsync(serverlessFile);
         actualContent.ShouldContain($"\"Microsoft.NetCore.Component.Runtime.{channel}\"");
@@ -45,7 +44,7 @@ public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
         actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
 
         // Assert
-        actualUpdated.ShouldBeFalse();
+        actualUpdated.ShouldBe(UpgradeResult.None);
     }
 
     [Fact]
@@ -102,10 +101,10 @@ public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
         var target = new VisualStudioComponentUpgrader(fixture.Console, options, logger);
 
         // Act
-        bool actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        UpgradeResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
 
         // Assert
-        actualUpdated.ShouldBeTrue();
+        actualUpdated.ShouldBe(UpgradeResult.Success);
 
         string actualContent = await File.ReadAllTextAsync(vsconfig);
         actualContent.NormalizeLineEndings().TrimEnd().ShouldBe(expectedContent.NormalizeLineEndings().TrimEnd());
@@ -114,7 +113,7 @@ public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
         actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
 
         // Assert
-        actualUpdated.ShouldBeFalse();
+        actualUpdated.ShouldBe(UpgradeResult.None);
     }
 
     [Theory]
@@ -145,9 +144,9 @@ public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
         var target = new VisualStudioComponentUpgrader(fixture.Console, options, logger);
 
         // Act
-        bool actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        UpgradeResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
 
         // Assert
-        actual.ShouldBeFalse();
+        actual.ShouldBe(UpgradeResult.None);
     }
 }


### PR DESCRIPTION
- Add `--warnings-as-errors` switch to exit with a non-zero status if any warnings occur.
- Support reporting warnings and errors from upgrade steps.
- Improve the code logic flow when an error/warning occurs.
- Fix typo in namespace.
