### PR TITLE
Update AWS Lambda Tools defaults

### DIFF
--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -61,6 +61,7 @@ public static class ServiceCollectionExtensions
 
     private static IServiceCollection AddUpgraders(this IServiceCollection services)
     {
+        services.AddSingleton<IUpgrader, AwsLambdaToolsUpgrader>();
         services.AddSingleton<IUpgrader, GlobalJsonUpgrader>();
         services.AddSingleton<IUpgrader, PackageVersionUpgrader>();
         services.AddSingleton<IUpgrader, ServerlessUpgrader>();

--- a/src/DotNetBumper.Core/Upgraders/AwsLambdaToolsUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/AwsLambdaToolsUpgrader.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+internal sealed partial class AwsLambdaToolsUpgrader(
+    IAnsiConsole console,
+    IOptions<UpgradeOptions> options,
+    ILogger<AwsLambdaToolsUpgrader> logger) : FileUpgrader(console, options, logger)
+{
+    protected override string Action => "Upgrading AWS Lambda Tools defaults";
+
+    protected override string InitialStatus => "Update AWS Lambda Tools";
+
+    protected override IReadOnlyList<string> Patterns => ["aws-lambda-tools-defaults.json"];
+
+    protected override async Task<UpgradeResult> UpgradeCoreAsync(
+        UpgradeInfo upgrade,
+        IReadOnlyList<string> fileNames,
+        StatusContext context,
+        CancellationToken cancellationToken)
+    {
+        Log.UpgradingAwsLambdaTools(logger);
+
+        UpgradeResult result = UpgradeResult.None;
+
+        foreach (var path in fileNames)
+        {
+            var name = RelativeName(path);
+
+            context.Status = StatusMessage($"Parsing {name}...");
+
+            if (!TryEditDefaults(path, upgrade.Channel, out var configuration))
+            {
+                continue;
+            }
+
+            context.Status = StatusMessage($"Updating {name}...");
+
+            await UpdateConfigurationAsync(path, configuration, cancellationToken);
+
+            result = UpgradeResult.Success;
+        }
+
+        return result;
+    }
+
+    private static async Task UpdateConfigurationAsync(string path, JsonObject defaults, CancellationToken cancellationToken)
+    {
+        using var stream = File.OpenWrite(path);
+        using var writer = new Utf8JsonWriter(stream, new() { Indented = true });
+
+        defaults.WriteTo(writer);
+        await writer.FlushAsync(cancellationToken);
+
+        await stream.WriteAsync(Encoding.UTF8.GetBytes(Environment.NewLine), cancellationToken);
+    }
+
+    private bool TryEditDefaults(string path, Version channel, [NotNullWhen(true)] out JsonObject? configuration)
+    {
+        configuration = null;
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            configuration = JsonNode.Parse(stream) as JsonObject;
+
+            if (configuration is null)
+            {
+                return false;
+            }
+        }
+        catch (JsonException ex)
+        {
+            Log.ParseConfigurationFailed(logger, path, ex);
+            return false;
+        }
+
+        bool updated = false;
+
+        if (configuration.TryGetPropertyValue("framework", out var framework) &&
+            framework?.GetValueKind() is JsonValueKind.String)
+        {
+            string value = framework.GetValue<string>();
+            var version = value.ToVersionFromTargetFramework();
+
+            if (version is { } && version < channel)
+            {
+                framework.ReplaceWith(JsonValue.Create(channel.ToTargetFramework()));
+                updated = true;
+            }
+        }
+
+        if (configuration.TryGetPropertyValue("function-runtime", out var runtime) &&
+            runtime?.GetValueKind() is JsonValueKind.String)
+        {
+            string value = runtime.GetValue<string>();
+            var runtimeVersion = value.ToVersionFromLambdaRuntime();
+
+            if (runtimeVersion is { } && runtimeVersion < channel)
+            {
+                runtime.ReplaceWith(JsonValue.Create(channel.ToLambdaRuntime()));
+                updated = true;
+            }
+        }
+
+        return updated;
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 1,
+            Level = LogLevel.Debug,
+            Message = "Upgrading AWS Lambda Tools defaults.")]
+        public static partial void UpgradingAwsLambdaTools(ILogger logger);
+
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Warning,
+            Message = "Unable to parse configuration file {FileName}.")]
+        public static partial void ParseConfigurationFailed(
+            ILogger logger,
+            string fileName,
+            Exception exception);
+    }
+}

--- a/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
@@ -108,7 +108,7 @@ internal sealed partial class TargetFrameworkUpgrader(
 
         foreach (var tfm in tfms)
         {
-            var version = tfm.ToVersion();
+            var version = tfm.ToVersionFromTargetFramework();
 
             if (version is not null && version > candidate)
             {

--- a/src/DotNetBumper.Core/Upgraders/VisualStudioCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/VisualStudioCodeUpgrader.cs
@@ -141,7 +141,7 @@ internal sealed partial class VisualStudioCodeUpgrader(
 
                     if (TargetFrameworkMoniker().IsMatch(segment))
                     {
-                        if (segment.ToVersion() is { } version && version < channel)
+                        if (segment.ToVersionFromTargetFramework() is { } version && version < channel)
                         {
                             segment = channel.ToTargetFramework();
                             updated = true;

--- a/src/DotNetBumper.Core/VersionExtensions.cs
+++ b/src/DotNetBumper.Core/VersionExtensions.cs
@@ -16,7 +16,33 @@ internal static class VersionExtensions
     public static string ToTargetFramework(this NuGetVersion version)
         => $"net{version.Major}.{version.Minor}";
 
-    public static Version? ToVersion(this string targetFramework)
+    public static Version? ToVersionFromLambdaRuntime(this string runtime)
+    {
+        if (runtime.StartsWith("dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            var span = runtime.AsSpan();
+            int digit = span.IndexOfAnyInRange('1', '9');
+
+            if (digit is not -1)
+            {
+                var number = span[digit..];
+
+                if (number.IndexOf('.') is -1)
+                {
+                    number = $"{number}.0";
+                }
+
+                if (Version.TryParse(number, out var version))
+                {
+                    return version;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public static Version? ToVersionFromTargetFramework(this string targetFramework)
     {
         if (targetFramework.StartsWith("net", StringComparison.OrdinalIgnoreCase))
         {

--- a/tests/DotNetBumper.Tests/Upgraders/AwsLambdaToolsUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/AwsLambdaToolsUpgraderTests.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+public class AwsLambdaToolsUpgraderTests(ITestOutputHelper outputHelper)
+{
+    [Theory]
+    [InlineData("7.0")]
+    [InlineData("8.0")]
+    [InlineData("9.0")]
+    public async Task UpgradeAsync_Upgrades_Properties(string channel)
+    {
+        // Arrange
+        string fileContents =
+            """
+            {
+              "profile": "alexa-london-travel",
+              "region": "eu-west-1",
+              "configuration": "Release",
+              "framework": "net6.0",
+              "function-architecture": "arm64",
+              "function-handler": "MyApplication",
+              "function-memory-size": 192,
+              "function-runtime": "dotnet6",
+              "function-timeout": 10
+            }
+            """;
+
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string lambdaDefaultsFile = await fixture.Project.AddFileAsync("aws-lambda-tools-defaults.json", fileContents);
+
+        var upgrade = new UpgradeInfo()
+        {
+            Channel = Version.Parse(channel),
+            EndOfLife = DateOnly.MaxValue,
+            ReleaseType = DotNetReleaseType.Lts,
+            SdkVersion = new($"{channel}.100"),
+        };
+
+        var options = Options.Create(new UpgradeOptions() { ProjectPath = fixture.Project.DirectoryName });
+        var logger = outputHelper.ToLogger<AwsLambdaToolsUpgrader>();
+        var target = new AwsLambdaToolsUpgrader(fixture.Console, options, logger);
+
+        // Act
+        UpgradeResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBe(UpgradeResult.Success);
+
+        string actualContent = await File.ReadAllTextAsync(lambdaDefaultsFile);
+
+        var defaults = JsonDocument.Parse(actualContent);
+        defaults.RootElement.ValueKind.ShouldBe(JsonValueKind.Object);
+
+        defaults.RootElement.TryGetProperty("framework", out var framework).ShouldBeTrue();
+        framework.ValueKind.ShouldBe(JsonValueKind.String);
+        framework.GetString().ShouldBe($"net{channel}");
+
+        defaults.RootElement.TryGetProperty("function-runtime", out var runtime).ShouldBeTrue();
+        runtime.ValueKind.ShouldBe(JsonValueKind.String);
+        runtime.GetString().ShouldBe($"dotnet{upgrade.Channel.Major}");
+
+        // Act
+        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBe(UpgradeResult.None);
+    }
+
+    [Theory]
+    [InlineData("Not JSON")]
+    [InlineData("[]")]
+    [InlineData("[]]")]
+    [InlineData("\"value\"")]
+    [InlineData("{}")]
+    [InlineData("{\"framework\":1}")]
+    [InlineData("{\"framework\":true}")]
+    [InlineData("{\"framework\":\"bar\"}")]
+    [InlineData("{\"framework\":{}}")]
+    [InlineData("{\"framework\":[]}")]
+    [InlineData("{\"function-runtime\":1}")]
+    [InlineData("{\"function-runtime\":true}")]
+    [InlineData("{\"function-runtime\":\"bar\"}")]
+    [InlineData("{\"function-runtime\":{}}")]
+    [InlineData("{\"function-runtime\":[]}")]
+    public async Task UpgradeAsync_Handles_Invalid_Json(string content)
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string vsconfig = await fixture.Project.AddFileAsync("aws-lambda-tools-defaults.json", content);
+
+        var upgrade = new UpgradeInfo()
+        {
+            Channel = new(8, 0),
+            EndOfLife = DateOnly.MaxValue,
+            ReleaseType = DotNetReleaseType.Lts,
+            SdkVersion = new("8.0.201"),
+        };
+
+        var options = Options.Create(new UpgradeOptions() { ProjectPath = fixture.Project.DirectoryName });
+        var logger = outputHelper.ToLogger<AwsLambdaToolsUpgrader>();
+        var target = new AwsLambdaToolsUpgrader(fixture.Console, options, logger);
+
+        // Act
+        UpgradeResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actual.ShouldBe(UpgradeResult.None);
+    }
+}


### PR DESCRIPTION
- Update the target framework and runtime in `aws-lambda-tools-defaults.json`.
- Add helpers for parsing the version from a lambda runtime and target framework moniker.

Resolves #13.
