### PR TITLE
Log warning if dotnet outdated fails

### DIFF
--- a/src/DotNetBumper.Core/DotNetProcess.cs
+++ b/src/DotNetBumper.Core/DotNetProcess.cs
@@ -59,6 +59,7 @@ public sealed partial class DotNetProcess(ILogger<DotNetProcess> logger)
 
         var result = new DotNetResult(
             process.ExitCode == 0,
+            process.ExitCode,
             output,
             error);
 

--- a/src/DotNetBumper.Core/DotNetResult.cs
+++ b/src/DotNetBumper.Core/DotNetResult.cs
@@ -7,9 +7,11 @@ namespace MartinCostello.DotNetBumper;
 /// Represents the result of running a .NET process.
 /// </summary>
 /// <param name="Success">Whether the process exited successfully.</param>
+/// <param name="ExitCode">The exit code from the process.</param>
 /// <param name="StandardOutput">The standard output from the process.</param>
 /// <param name="StandardError">The standard error from the process.</param>
 public sealed record DotNetResult(
     bool Success,
+    int ExitCode,
     string StandardOutput,
     string StandardError);

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -227,7 +227,7 @@ public partial class ProjectUpgrader(
             }
         }
 
-        return new(true, string.Empty, string.Empty);
+        return new(true, 0, string.Empty, string.Empty);
     }
 
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
@@ -15,6 +15,8 @@ internal sealed partial class GlobalJsonUpgrader(
     IOptions<UpgradeOptions> options,
     ILogger<GlobalJsonUpgrader> logger) : FileUpgrader(console, options, logger)
 {
+    public override int Priority => -1;
+
     protected override string Action => "Upgrading .NET SDK";
 
     protected override string InitialStatus => "Update SDK version";

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -127,6 +127,10 @@ internal sealed partial class PackageVersionUpgrader(
 
         if (!result.Success)
         {
+            Console.WriteLine();
+            Console.MarkupLineInterpolated($"[yellow]:warning: Failed to upgrade NuGet packages for {RelativeName(directory)}.[/]");
+            Console.MarkupLineInterpolated($"[yellow]:warning: dotnet outdated exited with code {result.ExitCode}.[/]");
+
             return UpgradeResult.Warning;
         }
 


### PR DESCRIPTION
- If `dotnet outdated` does not return 0, print a warning so that the process does not say there was a warning without saying what it was. Adding `--no-restore` makes the warnings go away, but it then breaks some of the tests.
- Run the .NET SDK upgrade as the first step.
