### PR TITLE
Update any MSBuild properties containing TFMs

### DIFF
--- a/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
@@ -19,7 +19,7 @@ internal sealed partial class TargetFrameworkUpgrader(
 
     protected override string InitialStatus => "Update TFMs";
 
-    protected override IReadOnlyList<string> Patterns => ["*.csproj", "*.fsproj"];
+    protected override IReadOnlyList<string> Patterns => ["Directory.Build.props", "*.csproj", "*.fsproj"];
 
     protected override async Task<UpgradeResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,
@@ -40,7 +40,7 @@ internal sealed partial class TargetFrameworkUpgrader(
 
             (var project, var encoding) = await LoadProjectAsync(filePath, cancellationToken);
 
-            if (project is null)
+            if (project is null || project.Root is null)
             {
                 result = result.Max(UpgradeResult.Warning);
                 continue;
@@ -49,30 +49,14 @@ internal sealed partial class TargetFrameworkUpgrader(
             bool edited = false;
             string newTfm = upgrade.Channel.ToTargetFramework();
 
-            var property = project
-                .Root?
-                .Element("PropertyGroup")?
-                .Element("TargetFramework");
-
-            if (property is not null &&
-                !string.Equals(property.Value, newTfm, StringComparison.Ordinal) &&
-                CanUpgrade(property.Value, upgrade.Channel))
+            foreach (var property in project.Root.Elements("PropertyGroup").Elements())
             {
-                property.SetValue(newTfm);
-                edited = true;
-            }
-
-            property = project
-                .Root?
-                .Element("PropertyGroup")?
-                .Element("TargetFrameworks");
-
-            if (property is not null &&
-                !property.Value.Contains(newTfm, StringComparison.Ordinal) &&
-                CanUpgrade(property.Value, upgrade.Channel))
-            {
-                property.SetValue($"{property.Value};{newTfm}");
-                edited = true;
+                if (!string.Equals(property.Value, newTfm, StringComparison.Ordinal) &&
+                    CanUpgradeTargetFramework(property.Value, upgrade.Channel))
+                {
+                    property.SetValue(newTfm);
+                    edited = true;
+                }
             }
 
             if (edited)
@@ -102,21 +86,41 @@ internal sealed partial class TargetFrameworkUpgrader(
         return result;
     }
 
-    private static bool CanUpgrade(string targetFrameworks, Version candidate)
+    private static bool CanUpgradeTargetFramework(ReadOnlySpan<char> property, Version channel)
     {
-        var tfms = targetFrameworks.Split(';', StringSplitOptions.RemoveEmptyEntries);
+        const char Delimiter = ';';
+        var remaining = property;
 
-        foreach (var tfm in tfms)
+        bool allValidTfms = false;
+
+        // Test for ";;;" and "net6.0;;net7.0"
+        while (!remaining.IsEmpty)
         {
-            var version = tfm.ToVersionFromTargetFramework();
+            int index = remaining.IndexOf(Delimiter);
+            var part = index is -1 ? remaining : remaining[..index];
 
-            if (version is not null && version > candidate)
+            if (!part.IsTargetFrameworkMoniker())
             {
                 return false;
             }
+
+            var version = part.ToVersionFromTargetFramework();
+
+            if (version is null || version > channel)
+            {
+                return false;
+            }
+
+            allValidTfms = true;
+            remaining = remaining[(index + 1)..];
+
+            if (index is -1)
+            {
+                break;
+            }
         }
 
-        return true;
+        return allValidTfms;
     }
 
     private async Task<(XDocument? Project, Encoding? Encoding)> LoadProjectAsync(

--- a/src/DotNetBumper.Core/Upgraders/VisualStudioCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/VisualStudioCodeUpgrader.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Spectre.Console;
@@ -72,9 +71,6 @@ internal sealed partial class VisualStudioCodeUpgrader(
         return result;
     }
 
-    [GeneratedRegex("^net(coreapp)?[1-9]+\\.[0-9]{1}$")]
-    private static partial Regex TargetFrameworkMoniker();
-
     private static async Task UpdateConfigurationAsync(string path, JsonObject configuration, CancellationToken cancellationToken)
     {
         var options = new JsonWriterOptions()
@@ -111,7 +107,7 @@ internal sealed partial class VisualStudioCodeUpgrader(
 
             string value = node.GetValue<string>();
 
-            if (value.Split(PathSeparators).Any((p) => TargetFrameworkMoniker().IsMatch(p)))
+            if (value.Split(PathSeparators).Any((p) => p.IsTargetFrameworkMoniker()))
             {
                 var builder = new StringBuilder();
                 var remaining = value.AsSpan();
@@ -128,9 +124,9 @@ internal sealed partial class VisualStudioCodeUpgrader(
                         break;
                     }
 
-                    string segment = new(remaining[0..index]);
+                    string segment = new(remaining[..index]);
 
-                    if (TargetFrameworkMoniker().IsMatch(segment))
+                    if (segment.IsTargetFrameworkMoniker())
                     {
                         if (segment.ToVersionFromTargetFramework() is { } version && version < channel)
                         {

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -236,7 +236,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
 
         return await Bumper.RunAsync(
             fixture.Console,
-            [fixture.Project.DirectoryName, "--verbose", ..args],
+            [fixture.Project.DirectoryName, "--verbose", "--warnings-as-errors", ..args],
             (builder) => builder.AddXUnit(fixture).AddFilter(LogFilter),
             cts.Token);
     }

--- a/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
@@ -97,6 +97,8 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
     [InlineData("<Project><PropertyGroup></PropertyGroup></Project>", UpgradeResult.None)]
     [InlineData("<Project><PropertyGroup><SomeProperty></SomeProperty></PropertyGroup></Project>", UpgradeResult.None)]
     [InlineData("<Project><PropertyGroup><SomeProperty>;;</SomeProperty></PropertyGroup></Project>", UpgradeResult.None)]
+    [InlineData("<Project><PropertyGroup><SomeProperty>8.0</SomeProperty></PropertyGroup></Project>", UpgradeResult.None)]
+    [InlineData("<Project><PropertyGroup><SomeProperty>SomeValue</SomeProperty></PropertyGroup></Project>", UpgradeResult.None)]
     public async Task UpgradeAsync_Handles_Invalid_Xml(string content, UpgradeResult expected)
     {
         // Arrange

--- a/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+using Microsoft.Extensions.Options;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
+{
+    public static TheoryData<string, string, string, string, string> TargetFrameworks()
+    {
+        string[] channels = ["7.0", "8.0", "9.0"];
+        string[] fileNames = ["Directory.Build.props", "src/MyProject.csproj", "src/MyProject.fsproj"];
+
+        var testCases = new TheoryData<string, string, string, string, string>();
+
+        foreach (var channel in channels)
+        {
+            foreach (var fileName in fileNames)
+            {
+                testCases.Add(channel, fileName, "DefaultTargetFramework", "net6.0", $"net{channel}");
+                testCases.Add(channel, fileName, "TargetFramework", "net6.0", $"net{channel}");
+                testCases.Add(channel, fileName, "TargetFrameworks", "net5.0;net6.0", $"net5.0;net6.0;net{channel}");
+                testCases.Add(channel, fileName, "TargetFrameworks", "net5.0;;;;net6.0", $"net5.0;;;;net6.0;net{channel}");
+            }
+        }
+
+        return testCases;
+    }
+
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task UpgradeAsync_Upgrades_Properties(
+        string channel,
+        string fileName,
+        string propertyName,
+        string propertyValue,
+        string expectedValue)
+    {
+        // Arrange
+        string fileContents =
+            $"""
+             <Project Sdk="Microsoft.NET.Sdk">
+               <PropertyGroup>
+                 <{propertyName}>{propertyValue}</{propertyName}>
+               </PropertyGroup>
+             </Project>
+             """;
+
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string projectFile = await fixture.Project.AddFileAsync(fileName, fileContents);
+
+        var upgrade = new UpgradeInfo()
+        {
+            Channel = Version.Parse(channel),
+            EndOfLife = DateOnly.MaxValue,
+            ReleaseType = DotNetReleaseType.Lts,
+            SdkVersion = new($"{channel}.100"),
+        };
+
+        var options = Options.Create(new UpgradeOptions() { ProjectPath = fixture.Project.DirectoryName });
+        var logger = outputHelper.ToLogger<TargetFrameworkUpgrader>();
+        var target = new TargetFrameworkUpgrader(fixture.Console, options, logger);
+
+        // Act
+        UpgradeResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBe(UpgradeResult.Success);
+
+        string actualContent = await File.ReadAllTextAsync(projectFile);
+
+        var xml = await fixture.Project.GetFileAsync(projectFile);
+        var project = XDocument.Parse(xml);
+
+        var actualValue = project
+            .Root?
+            .Element("PropertyGroup")?
+            .Element(propertyName)?
+            .Value;
+
+        actualValue.ShouldBe(expectedValue);
+
+        // Act
+        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBe(UpgradeResult.None);
+    }
+
+    [Theory]
+    [InlineData("Not XML", UpgradeResult.Warning)]
+    [InlineData("<>", UpgradeResult.Warning)]
+    [InlineData("<Project></Project>", UpgradeResult.None)]
+    [InlineData("<Project><PropertyGroup></PropertyGroup></Project>", UpgradeResult.None)]
+    [InlineData("<Project><PropertyGroup><SomeProperty></SomeProperty></PropertyGroup></Project>", UpgradeResult.None)]
+    [InlineData("<Project><PropertyGroup><SomeProperty>;;</SomeProperty></PropertyGroup></Project>", UpgradeResult.None)]
+    public async Task UpgradeAsync_Handles_Invalid_Xml(string content, UpgradeResult expected)
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string project = await fixture.Project.AddFileAsync("Project.csproj", content);
+
+        var upgrade = new UpgradeInfo()
+        {
+            Channel = new(8, 0),
+            EndOfLife = DateOnly.MaxValue,
+            ReleaseType = DotNetReleaseType.Lts,
+            SdkVersion = new("8.0.201"),
+        };
+
+        var options = Options.Create(new UpgradeOptions() { ProjectPath = fixture.Project.DirectoryName });
+        var logger = outputHelper.ToLogger<TargetFrameworkUpgrader>();
+        var target = new TargetFrameworkUpgrader(fixture.Console, options, logger);
+
+        // Act
+        UpgradeResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actual.ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
- Update any MSBuild properties containing TFMs.
- Include `Directory.Build.props` in files to update properties for.
- Set `--warnings-as-errors` in end-to-end tests.

Resolves #14.