### PR TITLE
Handle unsupported lambda runtimes and UX polish

### DIFF
--- a/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
+++ b/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
@@ -73,7 +73,7 @@ public static class IAnsiConsoleExtensions
     public static void WriteUnsupportedLambdaRuntimeWarning(this IAnsiConsole console, UpgradeInfo upgrade)
     {
         string qualifier = upgrade.ReleaseType is DotNetReleaseType.Lts ? "yet " : string.Empty;
-        console.WriteWarningLine($".NET {upgrade.Channel} is not {qualifier}supported by AWS Lambda.[/]");
+        console.WriteWarningLine($".NET {upgrade.Channel} is not {qualifier}supported by AWS Lambda.");
     }
 
     /// <summary>

--- a/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
+++ b/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Spectre.Console;
+
+namespace MartinCostello.DotNetBumper;
+
+/// <summary>
+/// A class containing extension methods for the <see cref="IAnsiConsole"/> interface. This class cannot be inherited.
+/// </summary>
+public static class IAnsiConsoleExtensions
+{
+    /// <summary>
+    /// Writes a message about use of a .NET runtime whose support period ends soon to the console.
+    /// </summary>
+    /// <param name="console">The <see cref="IAnsiConsole"/> to use.</param>
+    /// <param name="upgrade">The <see cref="UpgradeInfo"/> that is nearing the end of support.</param>
+    /// <param name="daysRemaining">The number of days remaining until support ends.</param>
+    public static void WriteRuntimeNearingEndOfSupportWarning(this IAnsiConsole console, UpgradeInfo upgrade, double daysRemaining)
+    {
+        var eolUtc = upgrade.EndOfLife.GetValueOrDefault().ToDateTime(TimeOnly.MinValue);
+        console.WriteWarningLine($"Support for .NET {upgrade.Channel} ends in {daysRemaining:N0} days on {eolUtc:D}.");
+        console.WriteWarningLine("See [link=https://dotnet.microsoft.com/platform/support/policy/dotnet-core].NET and .NET Core Support Policy[/] for more information.");
+    }
+
+    /// <summary>
+    /// Writes an error message to the console.
+    /// </summary>
+    /// <param name="console">The <see cref="IAnsiConsole"/> to use.</param>
+    /// <param name="message">The error message to write.</param>
+    public static void WriteErrorLine(this IAnsiConsole console, string message)
+    {
+        console.MarkupLineInterpolated($"[red]:cross_mark: {message}[/]");
+    }
+
+    /// <summary>
+    /// Writes an exception message to the console.
+    /// </summary>
+    /// <param name="console">The <see cref="IAnsiConsole"/> to use.</param>
+    /// <param name="message">The exception message to write.</param>
+    /// <param name="exception">The exception to write.</param>
+    public static void WriteExceptionLine(this IAnsiConsole console, string message, Exception exception)
+    {
+        console.WriteErrorLine(message);
+        console.WriteException(exception);
+    }
+
+    /// <summary>
+    /// Writes a progress message to the console.
+    /// </summary>
+    /// <param name="console">The <see cref="IAnsiConsole"/> to use.</param>
+    /// <param name="message">The progress message to write.</param>
+    public static void WriteProgressLine(this IAnsiConsole console, string message)
+    {
+        console.MarkupLineInterpolated($"[grey]{message}[/]");
+    }
+
+    /// <summary>
+    /// Writes as success message to the console.
+    /// </summary>
+    /// <param name="console">The <see cref="IAnsiConsole"/> to use.</param>
+    /// <param name="message">The success message to write.</param>
+    public static void WriteSuccessLine(this IAnsiConsole console, string message)
+    {
+        console.MarkupLineInterpolated($"[green]:check_mark_button: {message}[/]");
+    }
+
+    /// <summary>
+    /// Writes a message about use of an unsupported AWS Lambda runtime to the console.
+    /// </summary>
+    /// <param name="console">The <see cref="IAnsiConsole"/> to use.</param>
+    /// <param name="upgrade">The <see cref="UpgradeInfo"/> that is not supported.</param>
+    public static void WriteUnsupportedLambdaRuntimeWarning(this IAnsiConsole console, UpgradeInfo upgrade)
+    {
+        string qualifier = upgrade.ReleaseType is DotNetReleaseType.Lts ? "yet " : string.Empty;
+        console.WriteWarningLine($".NET {upgrade.Channel} is not {qualifier}supported by AWS Lambda.[/]");
+    }
+
+    /// <summary>
+    /// Writes a warning message to the console.
+    /// </summary>
+    /// <param name="console">The <see cref="IAnsiConsole"/> to use.</param>
+    /// <param name="message">The warning message to write.</param>
+    public static void WriteWarningLine(this IAnsiConsole console, string message)
+    {
+        console.MarkupLineInterpolated($"[yellow]:warning: {message}[/]");
+    }
+}

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -92,6 +92,10 @@ public partial class ProjectUpgrader(
             {
                 stepResult = await upgrader.UpgradeAsync(upgrade, cancellationToken);
             }
+            catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 stepResult = UpgradeResult.Error;

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -54,7 +54,7 @@ public partial class ProjectUpgrader(
 
         if (upgrade is null)
         {
-            console.MarkupLine("[yellow]:warning: No eligible .NET upgrade was found.[/]");
+            console.WriteWarningLine("No eligible .NET upgrade was found.");
             console.WriteLine();
             return 0;
         }
@@ -75,8 +75,7 @@ public partial class ProjectUpgrader(
                 var eolUtc = value.ToDateTime(TimeOnly.MinValue);
                 var days = (eolUtc - utcNow).TotalDays;
 
-                console.MarkupLineInterpolated($"[yellow]:warning: Support for .NET {upgrade.Channel} ends in {days:N0} days on {eolUtc:D}.[/]");
-                console.MarkupLine("[yellow]:warning: See [link=https://dotnet.microsoft.com/platform/support/policy/dotnet-core].NET and .NET Core Support Policy[/] for more information.[/]");
+                console.WriteRuntimeNearingEndOfSupportWarning(upgrade, days);
                 console.WriteLine();
             }
         }
@@ -98,8 +97,7 @@ public partial class ProjectUpgrader(
                 stepResult = UpgradeResult.Error;
 
                 console.WriteLine();
-                console.MarkupLine($"[red]:cross_mark: An error occurred while performing upgrade step {upgrader.GetType().Name}.[/]");
-                console.WriteException(ex);
+                console.WriteExceptionLine($"An error occurred while performing upgrade step {upgrader.GetType().Name}.", ex);
             }
 
             result = result.Max(stepResult);
@@ -108,7 +106,7 @@ public partial class ProjectUpgrader(
         if (result is UpgradeResult.Warning)
         {
             console.WriteLine();
-            console.MarkupLine("[yellow]:warning: One or more upgrade steps produced a warning.[/]");
+            console.WriteWarningLine("One or more upgrade steps produced a warning.");
         }
 
         if (result is UpgradeResult.Success or UpgradeResult.Warning)
@@ -121,7 +119,7 @@ public partial class ProjectUpgrader(
 
             if (options.Value.TestUpgrade)
             {
-                console.MarkupLine("[grey]Verifying upgrade...[/]");
+                console.WriteProgressLine("Verifying upgrade...");
 
                 var projects = ProjectHelpers.FindProjects(ProjectPath);
 
@@ -129,8 +127,8 @@ public partial class ProjectUpgrader(
                 {
                     result = result.Max(UpgradeResult.Warning);
 
-                    console.MarkupLine("[yellow]:warning: Could not find any test projects.[/]");
-                    console.MarkupLine("[yellow]:warning: The project may not be in a working state.[/]");
+                    console.WriteWarningLine("Could not find any test projects.");
+                    console.WriteWarningLine("The project may not be in a working state.");
                 }
                 else
                 {
@@ -148,23 +146,23 @@ public partial class ProjectUpgrader(
 
                     if (testResult.Success)
                     {
-                        console.MarkupLine("[green]:check_mark_button: Upgrade successfully tested.[/]");
+                        console.WriteSuccessLine("Upgrade successfully tested.");
                     }
                     else
                     {
-                        console.MarkupLine("[yellow]:warning: The project upgrade did not result in a successful test run.[/]");
-                        console.MarkupLine("[yellow]:warning: The project may not be in a working state.[/]");
+                        console.WriteWarningLine("The project upgrade did not result in a successful test run.");
+                        console.WriteWarningLine("The project may not be in a working state.");
 
                         if (!string.IsNullOrWhiteSpace(testResult.StandardError))
                         {
                             console.WriteLine();
-                            console.MarkupLineInterpolated($"[grey]{testResult.StandardError}[/]");
+                            console.WriteProgressLine(testResult.StandardError);
                         }
 
                         if (!string.IsNullOrWhiteSpace(testResult.StandardOutput))
                         {
                             console.WriteLine();
-                            console.MarkupLineInterpolated($"[grey]{testResult.StandardOutput}[/]");
+                            console.WriteProgressLine(testResult.StandardOutput);
                         }
                     }
                 }
@@ -181,8 +179,8 @@ public partial class ProjectUpgrader(
         {
             Log.NothingToUpgrade(logger, ProjectPath);
 
-            console.MarkupLine("[yellow]:warning: The project upgrade did not result in any changes being made.[/]");
-            console.MarkupLine("[yellow]:warning: Maybe the project has already been upgraded?[/]");
+            console.WriteWarningLine("The project upgrade did not result in any changes being made.");
+            console.WriteWarningLine("Maybe the project has already been upgraded?");
         }
         else
         {

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -190,7 +190,7 @@ public partial class ProjectUpgrader(
         {
             (string emoji, string color, string description) = result switch
             {
-                UpgradeResult.Warning => (":warning:", "yellow", "succeeded with warnings"),
+                UpgradeResult.Warning => (":warning:", "yellow", "completed with warnings"),
                 _ => (":cross_mark:", "red", "failed"),
             };
 

--- a/src/DotNetBumper.Core/UpgradeOptionsValidator.cs
+++ b/src/DotNetBumper.Core/UpgradeOptionsValidator.cs
@@ -15,6 +15,11 @@ internal sealed class UpgradeOptionsValidator : IValidateOptions<UpgradeOptions>
             return ValidateOptionsResult.Fail($"The specified .NET channel \"{version}\" is invalid.");
         }
 
+        if (string.IsNullOrWhiteSpace(options.ProjectPath))
+        {
+            return ValidateOptionsResult.Fail("No path to a directory containing a .NET project/solution to upgrade specified.");
+        }
+
         if (!Directory.Exists(options.ProjectPath))
         {
             return ValidateOptionsResult.Fail($"The project path '{options.ProjectPath}' could not be found.");

--- a/src/DotNetBumper.Core/Upgraders/AwsLambdaToolsUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/AwsLambdaToolsUpgrader.cs
@@ -93,8 +93,7 @@ internal sealed partial class AwsLambdaToolsUpgrader(
                 if (upgrade.SupportPhase < DotNetSupportPhase.Active ||
                     upgrade.ReleaseType != DotNetReleaseType.Lts)
                 {
-                    string qualifier = upgrade.ReleaseType is DotNetReleaseType.Lts ? "yet " : string.Empty;
-                    Console.MarkupLine($"[yellow]:warning: .NET {upgrade.Channel} is {qualifier}supported by AWS Lambda.[/]");
+                    Console.WriteUnsupportedLambdaRuntimeWarning(upgrade);
                     result = result.Max(UpgradeResult.Warning);
                 }
                 else

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -128,8 +128,8 @@ internal sealed partial class PackageVersionUpgrader(
         if (!result.Success)
         {
             Console.WriteLine();
-            Console.MarkupLineInterpolated($"[yellow]:warning: Failed to upgrade NuGet packages for {RelativeName(directory)}.[/]");
-            Console.MarkupLineInterpolated($"[yellow]:warning: dotnet outdated exited with code {result.ExitCode}.[/]");
+            Console.WriteWarningLine($"Failed to upgrade NuGet packages for {RelativeName(directory)}.");
+            Console.WriteWarningLine($"dotnet outdated exited with code {result.ExitCode}.");
 
             return UpgradeResult.Warning;
         }

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -79,11 +79,16 @@ internal sealed partial class PackageVersionUpgrader(
 
         do
         {
-            var toolManifest = Directory.EnumerateFiles(Path.Combine(directory.FullName, ".config"), "dotnet-tools.json").FirstOrDefault();
+            var configPath = Path.Combine(directory.FullName, ".config");
 
-            if (toolManifest != null)
+            if (Directory.Exists(configPath))
             {
-                return new HiddenFile(toolManifest);
+                var toolManifest = Directory.EnumerateFiles(configPath, "dotnet-tools.json").FirstOrDefault();
+
+                if (toolManifest != null)
+                {
+                    return new HiddenFile(toolManifest);
+                }
             }
 
             directory = directory.Parent;

--- a/src/DotNetBumper.Core/Upgraders/ServerlessUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/ServerlessUpgrader.cs
@@ -58,8 +58,7 @@ internal sealed partial class ServerlessUpgrader(
                 {
                     if (!warningEmitted)
                     {
-                        string qualifier = upgrade.ReleaseType is DotNetReleaseType.Lts ? "yet " : string.Empty;
-                        Console.MarkupLine($"[yellow]:warning: .NET {upgrade.Channel} is {qualifier}supported by AWS Lambda.[/]");
+                        Console.WriteUnsupportedLambdaRuntimeWarning(upgrade);
                         Log.LambdaRuntimeNotSupported(Logger, upgrade.Channel);
                         warningEmitted = true;
                     }

--- a/src/DotNetBumper/Bumper.cs
+++ b/src/DotNetBumper/Bumper.cs
@@ -100,8 +100,7 @@ internal partial class Bumper(ProjectUpgrader upgrader)
                 oce.CancellationToken != cancellationToken)
             {
                 console.WriteLine();
-                console.MarkupLine("[red]Failed to upgrade project.[/]");
-                console.WriteException(ex);
+                console.WriteExceptionLine("Failed to upgrade project.", ex);
             }
 
             return 1;

--- a/src/DotNetBumper/Bumper.cs
+++ b/src/DotNetBumper/Bumper.cs
@@ -101,6 +101,11 @@ internal partial class Bumper(ProjectUpgrader upgrader)
                 console.WriteLine();
                 console.WriteWarningLine("Upgrade cancelled by user.");
             }
+            else if (ex is OptionsValidationException)
+            {
+                console.WriteLine();
+                console.WriteWarningLine(ex.Message);
+            }
             else
             {
                 console.WriteLine();

--- a/src/DotNetBumper/Bumper.cs
+++ b/src/DotNetBumper/Bumper.cs
@@ -96,8 +96,12 @@ internal partial class Bumper(ProjectUpgrader upgrader)
         {
             Log.UpgradeFailed(logger, ex);
 
-            if (ex is not OperationCanceledException oce ||
-                oce.CancellationToken != cancellationToken)
+            if (ex is OperationCanceledException oce && oce.CancellationToken != cancellationToken)
+            {
+                console.WriteLine();
+                console.WriteWarningLine("Upgrade cancelled by user.");
+            }
+            else
             {
                 console.WriteLine();
                 console.WriteExceptionLine("Failed to upgrade project.", ex);

--- a/src/DotNetBumper/Bumper.cs
+++ b/src/DotNetBumper/Bumper.cs
@@ -100,6 +100,7 @@ internal partial class Bumper(ProjectUpgrader upgrader)
             {
                 console.WriteLine();
                 console.WriteWarningLine("Upgrade cancelled by user.");
+                return 2;
             }
             else if (ex is OptionsValidationException)
             {

--- a/src/DotNetBumper/Bumper.cs
+++ b/src/DotNetBumper/Bumper.cs
@@ -96,7 +96,7 @@ internal partial class Bumper(ProjectUpgrader upgrader)
         {
             Log.UpgradeFailed(logger, ex);
 
-            if (ex is OperationCanceledException oce && oce.CancellationToken != cancellationToken)
+            if (ex is OperationCanceledException oce && oce.CancellationToken == cancellationToken)
             {
                 console.WriteLine();
                 console.WriteWarningLine("Upgrade cancelled by user.");

--- a/src/DotNetBumper/UpgradePostConfigureOptions.cs
+++ b/src/DotNetBumper/UpgradePostConfigureOptions.cs
@@ -13,9 +13,13 @@ internal sealed class UpgradePostConfigureOptions(IModelAccessor accessor) : IPo
         var command = (Bumper)accessor.GetModel();
 
         options.DotNetChannel ??= command.DotNetChannel;
-        options.ProjectPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(command.ProjectPath ?? Environment.CurrentDirectory));
         options.TestUpgrade = command.TestUpgrade;
         options.TreatWarningsAsErrors = command.WarningsAsErrors;
+
+        if (!string.IsNullOrWhiteSpace(command.ProjectPath))
+        {
+            options.ProjectPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(command.ProjectPath));
+        }
 
         if (command.UpgradeType is { } upgradeType)
         {

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -44,6 +44,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
         using var fixture = new UpgraderFixture(outputHelper);
 
         await fixture.Project.AddSolutionAsync("Project.sln");
+        await fixture.Project.AddToolManifestAsync();
 
         string globalJson = await fixture.Project.AddGlobalJsonAsync(testCase.SdkVersion);
         string vscode = await fixture.Project.AddVisualStudioCodeLaunchConfigurationsAsync();

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -218,6 +218,28 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
         actual.ShouldBe(0);
     }
 
+    [Fact]
+    public async Task Application_Returns_Two_If_Cancelled_By_User()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        int actual = await Bumper.RunAsync(
+            fixture.Console,
+            [fixture.Project.DirectoryName, "--verbose"],
+            (builder) =>
+            {
+                cts.Cancel();
+                return builder.AddXUnit(fixture);
+            },
+            cts.Token);
+
+        // Assert
+        actual.ShouldBe(2);
+    }
+
     private static async Task<int> RunAsync(UpgraderFixture fixture, IList<string> args)
     {
         static bool LogFilter(string? category, LogLevel level)

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
+using Spectre.Console.Testing;
 
 namespace MartinCostello.DotNetBumper;
 
@@ -238,6 +239,23 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
 
         // Assert
         actual.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Application_Validates_Project_Is_Specified()
+    {
+        // Arrange
+        using var console = new TestConsole();
+
+        // Act
+        int actual = await Bumper.RunAsync(
+            console,
+            [],
+            (builder) => builder.AddXUnit(outputHelper),
+            CancellationToken.None);
+
+        // Assert
+        actual.ShouldBe(1);
     }
 
     private static async Task<int> RunAsync(UpgraderFixture fixture, IList<string> args)

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -53,6 +53,27 @@ internal sealed class Project : IDisposable
         return await AddFileAsync(path, solution);
     }
 
+    public async Task<string> AddToolManifestAsync(string path = ".config/dotnet-tools.json")
+    {
+        var manifest =
+            """
+            {
+              "version": 1,
+              "isRoot": true,
+              "tools": {
+                "dotnet-outdated-tool": {
+                  "version": "4.6.0",
+                  "commands": [
+                    "dotnet-outdated"
+                  ]
+                }
+              }
+            }
+            """;
+
+        return await AddFileAsync(path, manifest);
+    }
+
     public async Task<string> AddVisualStudioCodeLaunchConfigurationsAsync(
         string channel = "6.0",
         string path = ".vscode/launch.json")

--- a/tests/DotNetBumper.Tests/Upgraders/ServerlessUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/ServerlessUpgraderTests.cs
@@ -105,12 +105,44 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
+    [InlineData("foo")]
     [InlineData("dotnetcore1.0")]
     [InlineData("dotnetcore2.0")]
     [InlineData("dotnetcore2.1")]
     [InlineData("dotnetcore3.1")]
     [InlineData("dotnet5.0")]
-    public async Task UpgradeAsync_Does_Not_Upgrade_Unsupported_Runtimes(string runtime)
+    [InlineData("go1.x")]
+    [InlineData("java8")]
+    [InlineData("java8.al2")]
+    [InlineData("java11")]
+    [InlineData("java17")]
+    [InlineData("java21")]
+    [InlineData("nodejs")]
+    [InlineData("nodejs4.3")]
+    [InlineData("nodejs4.3-edge")]
+    [InlineData("nodejs6.10")]
+    [InlineData("nodejs8.10")]
+    [InlineData("nodejs10.x")]
+    [InlineData("nodejs12.x")]
+    [InlineData("nodejs14.x")]
+    [InlineData("nodejs16.x")]
+    [InlineData("nodejs18.x")]
+    [InlineData("nodejs20.x")]
+    [InlineData("provided")]
+    [InlineData("provided.al2")]
+    [InlineData("provided.al2023")]
+    [InlineData("python2.7")]
+    [InlineData("python3.6")]
+    [InlineData("python3.7")]
+    [InlineData("python3.8")]
+    [InlineData("python3.9")]
+    [InlineData("python3.10")]
+    [InlineData("python3.11")]
+    [InlineData("python3.12")]
+    [InlineData("ruby2.5")]
+    [InlineData("ruby2.7")]
+    [InlineData("ruby3.2")]
+    public async Task UpgradeAsync_Does_Not_Upgrade_From_Unsupported_Runtimes(string runtime)
     {
         // Arrange
         string serverless =
@@ -148,16 +180,17 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData(5, DotNetReleaseType.Sts, DotNetSupportPhase.Eol)]
-    [InlineData(7, DotNetReleaseType.Sts, DotNetSupportPhase.Active)]
-    [InlineData(9, DotNetReleaseType.Sts, DotNetSupportPhase.Preview)]
-    [InlineData(9, DotNetReleaseType.Sts, DotNetSupportPhase.Active)]
-    [InlineData(10, DotNetReleaseType.Lts, DotNetSupportPhase.Preview)]
-    [InlineData(10, DotNetReleaseType.Lts, DotNetSupportPhase.GoLive)]
-    public async Task UpgradeAsync_Does_Not_Upgrade_Non_Lts_Runtimes(
+    [InlineData(5, DotNetReleaseType.Sts, DotNetSupportPhase.Eol, UpgradeResult.None)]
+    [InlineData(7, DotNetReleaseType.Sts, DotNetSupportPhase.Active, UpgradeResult.Warning)]
+    [InlineData(9, DotNetReleaseType.Sts, DotNetSupportPhase.Preview, UpgradeResult.Warning)]
+    [InlineData(9, DotNetReleaseType.Sts, DotNetSupportPhase.Active, UpgradeResult.Warning)]
+    [InlineData(10, DotNetReleaseType.Lts, DotNetSupportPhase.Preview, UpgradeResult.Warning)]
+    [InlineData(10, DotNetReleaseType.Lts, DotNetSupportPhase.GoLive, UpgradeResult.Warning)]
+    public async Task UpgradeAsync_Does_Not_Upgrade_To_Unsupported_Runtimes(
         int version,
         DotNetReleaseType releaseType,
-        DotNetSupportPhase supportPhase)
+        DotNetSupportPhase supportPhase,
+        UpgradeResult expected)
     {
         // Arrange
         string serverless =
@@ -191,7 +224,7 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         UpgradeResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
 
         // Assert
-        actual.ShouldBe(UpgradeResult.None);
+        actual.ShouldBe(expected);
     }
 
     [Fact]


### PR DESCRIPTION
- Require the user to explicitly specify a project directory.
- Emit a warning if trying to upgrade a project to a .NET release that is not supported by AWS Lambda.
- Do not print an exception to the console if the user cancelled and print a warning instead.
- Handle `OptionsValidationException` better if the user inputs invalid things.
- Avoid warning from `dotnet outdated` if the project contains a .NET Tools manifest.
- Add helper methods for consistency with outputting warnings, errors etc.

Resolves #24.
