### PR TITLE
Rename Priority to Order

### DIFF
--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -84,7 +84,7 @@ public partial class ProjectUpgrader(
 
         UpgradeResult result = UpgradeResult.None;
 
-        foreach (var upgrader in upgraders.OrderBy((p) => p.Priority))
+        foreach (var upgrader in upgraders.OrderBy((p) => p.Order))
         {
             UpgradeResult stepResult;
 

--- a/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
@@ -15,7 +15,7 @@ internal sealed partial class GlobalJsonUpgrader(
     IOptions<UpgradeOptions> options,
     ILogger<GlobalJsonUpgrader> logger) : FileUpgrader(console, options, logger)
 {
-    public override int Priority => -1;
+    public override int Order => -1;
 
     protected override string Action => "Upgrading .NET SDK";
 

--- a/src/DotNetBumper.Core/Upgraders/IUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/IUpgrader.cs
@@ -9,9 +9,9 @@ namespace MartinCostello.DotNetBumper.Upgraders;
 public interface IUpgrader
 {
     /// <summary>
-    /// Gets the global priority of the upgrader.
+    /// Gets the global order the upgrader should run in where lower numbers run before higher numbers.
     /// </summary>
-    int Priority { get; }
+    int Order { get; }
 
     /// <summary>
     /// Attempts to apply an upgrade to the project.

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -14,7 +14,7 @@ internal sealed partial class PackageVersionUpgrader(
     IOptions<UpgradeOptions> options,
     ILogger<PackageVersionUpgrader> logger) : Upgrader(console, options, logger)
 {
-    public override int Priority => int.MaxValue; // Packages need to be updated after the TFM so the packages relate to the update
+    public override int Order => int.MaxValue; // Packages need to be updated after the TFM so the packages relate to the update
 
     protected override string Action => "Upgrading NuGet packages";
 

--- a/src/DotNetBumper.Core/Upgraders/Upgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/Upgrader.cs
@@ -12,7 +12,7 @@ internal abstract partial class Upgrader(
     IOptions<UpgradeOptions> options,
     ILogger logger) : IUpgrader
 {
-    public virtual int Priority => 0;
+    public virtual int Order => 0;
 
     protected IAnsiConsole Console => console;
 


### PR DESCRIPTION
`Priority` implies higher numbers are more important, but the implementation is the opposite way around.
