### PR TITLE
Add disclaimer

### DIFF
--- a/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
+++ b/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
@@ -52,7 +52,7 @@ public static class IAnsiConsoleExtensions
     /// <param name="message">The error message to write.</param>
     public static void WriteErrorLine(this IAnsiConsole console, string message)
     {
-        console.MarkupLineInterpolated($"[red]:cross_mark: {message}[/]");
+        console.MarkupLineInterpolated($"[red]{Emoji.Known.CrossMark} {message}[/]");
     }
 
     /// <summary>
@@ -84,7 +84,7 @@ public static class IAnsiConsoleExtensions
     /// <param name="message">The success message to write.</param>
     public static void WriteSuccessLine(this IAnsiConsole console, string message)
     {
-        console.MarkupLineInterpolated($"[green]:check_mark_button: {message}[/]");
+        console.MarkupLineInterpolated($"[green]{Emoji.Known.CheckMarkButton} {message}[/]");
     }
 
     /// <summary>
@@ -105,6 +105,6 @@ public static class IAnsiConsoleExtensions
     /// <param name="message">The warning message to write.</param>
     public static void WriteWarningLine(this IAnsiConsole console, string message)
     {
-        console.MarkupLineInterpolated($"[yellow]:warning: {message}[/]");
+        console.MarkupLineInterpolated($"[yellow]{Emoji.Known.Warning} {message}[/]");
     }
 }

--- a/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
+++ b/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
@@ -11,6 +11,28 @@ namespace MartinCostello.DotNetBumper;
 public static class IAnsiConsoleExtensions
 {
     /// <summary>
+    /// Writes a disclaimer to the console.
+    /// </summary>
+    /// <param name="console">The <see cref="IAnsiConsole"/> to use.</param>
+    public static void WriteDisclaimer(this IAnsiConsole console)
+    {
+        string[] disclaimer =
+        [
+            $"{Emoji.Known.Megaphone} .NET Bumper upgrades are made on a best-effort basis.",
+            $"{Emoji.Known.MagnifyingGlassTiltedRight} You should [bold]always[/] review the changes and test your project to validate the upgrade.",
+        ];
+
+        var panel = new Panel(string.Join(Environment.NewLine, disclaimer))
+        {
+            Border = BoxBorder.Rounded,
+            Expand = true,
+            Header = new PanelHeader("[yellow]Disclaimer[/]", Justify.Center),
+        };
+
+        console.Write(panel);
+    }
+
+    /// <summary>
     /// Writes a message about use of a .NET runtime whose support period ends soon to the console.
     /// </summary>
     /// <param name="console">The <see cref="IAnsiConsole"/> to use.</param>

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -151,6 +151,8 @@ public partial class ProjectUpgrader(
         if (result is ProcessingResult.Success)
         {
             console.MarkupLine($"[aqua]{name}[/] upgrade to [white on purple].NET {upgrade.Channel}[/] [green]successful[/]! :rocket:");
+            console.WriteLine();
+            console.WriteDisclaimer();
         }
         else if (result is ProcessingResult.None)
         {

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -165,8 +165,8 @@ public partial class ProjectUpgrader(
         {
             (string emoji, string color, string description) = result switch
             {
-                ProcessingResult.Warning => (":warning:", "yellow", "completed with warnings"),
-                _ => (":cross_mark:", "red", "failed"),
+                ProcessingResult.Warning => (Emoji.Known.Warning, "yellow", "completed with warnings"),
+                _ => (Emoji.Known.CrossMark, "red", "failed"),
             };
 
             console.MarkupLine($"[aqua]{name}[/] upgrade to [purple].NET {upgrade.Channel}[/] [{color}]{description}[/]! {emoji}");


### PR DESCRIPTION
- Add disclaimer after successful upgrade.
- Use the `Emoji.Known` constants instead of literal names.

Resolves #38.

![image](https://github.com/martincostello/dotnet-bumper/assets/1439341/a7f6de64-1e40-4754-8ae7-b08578b0f0b1)
