### PR TITLE
Fix JSON corruption and support trailing commas and comments

### DIFF
--- a/src/DotNetBumper.Core/JsonExtensions.cs
+++ b/src/DotNetBumper.Core/JsonExtensions.cs
@@ -54,7 +54,7 @@ internal static class JsonExtensions
         await writer.FlushAsync(cancellationToken);
         await stream.WriteAsync(NewLineBytes, cancellationToken);
 
-        // If the edit may have caused the file to shrink, so truncate it to the new length
+        // The edit may have caused the file to shrink, so truncate it to the new length
         stream.SetLength(stream.Position);
     }
 }

--- a/src/DotNetBumper.Core/JsonExtensions.cs
+++ b/src/DotNetBumper.Core/JsonExtensions.cs
@@ -53,5 +53,8 @@ internal static class JsonExtensions
 
         await writer.FlushAsync(cancellationToken);
         await stream.WriteAsync(NewLineBytes, cancellationToken);
+
+        // If the edit may have caused the file to shrink, so truncate it to the new length
+        stream.SetLength(stream.Position);
     }
 }

--- a/src/DotNetBumper.Core/JsonHelpers.cs
+++ b/src/DotNetBumper.Core/JsonHelpers.cs
@@ -2,16 +2,23 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace MartinCostello.DotNetBumper;
 
 internal static class JsonHelpers
 {
+    internal static readonly JsonDocumentOptions DocumentOptions = new()
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip,
+    };
+
     public static bool TryLoadObject(string path, [NotNullWhen(true)] out JsonObject? root)
     {
         using var stream = File.OpenRead(path);
-        root = JsonNode.Parse(stream) as JsonObject;
+        root = JsonNode.Parse(stream, documentOptions: DocumentOptions) as JsonObject;
         return root is not null;
     }
 }

--- a/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
@@ -76,7 +76,7 @@ internal sealed partial class GlobalJsonUpgrader(
     {
         sdkVersion = null;
 
-        using var globalJson = JsonDocument.Parse(json);
+        using var globalJson = JsonDocument.Parse(json, JsonHelpers.DocumentOptions);
 
         if (globalJson.RootElement.TryGetProperty("sdk", out var sdk) &&
             sdk.TryGetProperty("version", out var version) &&

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -168,7 +168,7 @@ internal sealed partial class PackageVersionUpgrader(
 
             if (json.Length > 0)
             {
-                var updates = JsonDocument.Parse(json);
+                var updates = JsonDocument.Parse(json, JsonHelpers.DocumentOptions);
                 var projects = updates.RootElement.GetProperty("Projects");
 
                 foreach (var project in projects.EnumerateArray())

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -307,7 +307,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
                      category.StartsWith("System", StringComparison.Ordinal));
         }
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
 
         return await Bumper.RunAsync(
             fixture.Console,

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -134,6 +134,7 @@ internal sealed class Project : IDisposable
                     "name": "Launch app",
                     "type": "coreclr",
                     "request": "launch",
+                    // Comment
                     "program": "${workspaceFolder}/src/Project/bin/Debug/net{{channel}}/Project.dll",
                     "args": [],
                     "cwd": "${workspaceFolder}/src/Project",
@@ -141,7 +142,7 @@ internal sealed class Project : IDisposable
                     "internalConsoleOptions": "openOnSessionStart",
                     "serverReadyAction": {
                       "action": "openExternally",
-                      "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+                      "pattern": "\\bNow listening on:\\s+(https?://\\S+)",
                     },
                     "env": {
                       "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
- Set the stream length after saving JSON, otherwise if the content gets truncated (e.g. by reformatting), the original content is leftover and then makes the file invalid.
- Configure the `JsonDocument` and `JsonNode` parsing options to allow trailing commas and comments.

Resolves #45.
