### PR TITLE
Bump version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <VersionPrefix>0.1.1</VersionPrefix>
+    <VersionPrefix>0.1.2</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>

--- a/src/DotNetBumper/Bumper.cs
+++ b/src/DotNetBumper/Bumper.cs
@@ -99,6 +99,7 @@ internal partial class Bumper(ProjectUpgrader upgrader)
             {
                 console.Write(new FigletText(".NET Bumper").Color(Color.Purple));
                 console.MarkupLineInterpolated($"[{Color.Blue}]{GetVersion()}[/]");
+                console.WriteLine();
             }
 
             var stopwatch = Stopwatch.StartNew();


### PR DESCRIPTION
- Bump version to 0.1.2 for next release.
- Add a new line to the banner to make it a bit more distinct from what follows.
