### PR TITLE
Show leftover references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.1" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
+    <PackageVersion Include="Ignore" Version="0.1.50" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.2.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Spectre.Console" Version="0.48.0" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.48.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/src/DotNetBumper.Core/DotNetBumper.Core.csproj
+++ b/src/DotNetBumper.Core/DotNetBumper.Core.csproj
@@ -11,6 +11,7 @@
     <Title>MartinCostello.DotNetBumper.Core</Title>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Ignore" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/DotNetBumper.Core/FileHelpers.cs
+++ b/src/DotNetBumper.Core/FileHelpers.cs
@@ -9,6 +9,46 @@ internal static class FileHelpers
 {
     private static readonly Encoding UTF8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
+    public static string? FindDirectoryInProject(string path, string relativePath)
+    {
+        var directory = new DirectoryInfo(path);
+
+        do
+        {
+            var directoryName = Path.Combine(directory.FullName, relativePath);
+
+            if (Directory.Exists(directoryName))
+            {
+                return directoryName;
+            }
+
+            directory = directory.Parent;
+        }
+        while (directory is not null);
+
+        return null;
+    }
+
+    public static string? FindFileInProject(string path, string relativePath)
+    {
+        var directory = new DirectoryInfo(path);
+
+        do
+        {
+            var fileName = Path.Combine(directory.FullName, relativePath);
+
+            if (File.Exists(fileName))
+            {
+                return fileName;
+            }
+
+            directory = directory.Parent;
+        }
+        while (directory is not null);
+
+        return null;
+    }
+
     public static FileMetadata GetMetadata(string path)
     {
         using (FileHelpers.OpenRead(path, out var metadata))

--- a/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
@@ -69,7 +69,7 @@ internal sealed partial class LeftoverReferencesPostProcessor(
         {
             var table = new Table
             {
-                Title = new TableTitle("Remaining References"),
+                Title = new TableTitle($"Remaining References - {references.Sum((p) => p.Value.Count)}"),
             };
 
             table.AddColumn("Location");

--- a/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
@@ -9,14 +9,14 @@ using GitIgnore = Ignore.Ignore;
 
 namespace MartinCostello.DotNetBumper.PostProcessors;
 
-internal sealed partial class RemainingTargetFrameworksPostProcessor(
+internal sealed partial class LeftoverReferencesPostProcessor(
     IAnsiConsole console,
     IOptions<UpgradeOptions> options,
-    ILogger<RemainingTargetFrameworksPostProcessor> logger) : PostProcessor(console, options, logger)
+    ILogger<LeftoverReferencesPostProcessor> logger) : PostProcessor(console, options, logger)
 {
-    protected override string Action => "Running tests";
+    protected override string Action => "Find leftover references";
 
-    protected override string InitialStatus => "Test project";
+    protected override string InitialStatus => "Search files";
 
     protected override async Task<ProcessingResult> PostProcessCoreAsync(
         UpgradeInfo upgrade,
@@ -67,11 +67,11 @@ internal sealed partial class RemainingTargetFrameworksPostProcessor(
         {
             var table = new Table
             {
-                Title = new TableTitle("Remaining Target Framework References"),
+                Title = new TableTitle("Remaining References"),
             };
 
             table.AddColumn("Location");
-            table.AddColumn(new TableColumn("Match").RightAligned());
+            table.AddColumn("Match");
 
             foreach ((var file, var values) in references.OrderBy((p) => p.Key.RelativePath))
             {
@@ -81,6 +81,7 @@ internal sealed partial class RemainingTargetFrameworksPostProcessor(
                 }
             }
 
+            Console.WriteLine();
             Console.Write(table);
         }
 

--- a/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
@@ -36,6 +36,8 @@ internal sealed partial class LeftoverReferencesPostProcessor(
                 continue;
             }
 
+            context.Status = StatusMessage($"Searching {relativePath}...");
+
             int lineNumber = 0;
             var fileReferences = new List<PotentialFileEdit>();
 

--- a/src/DotNetBumper.Core/PostProcessors/PotentialFileEdit.cs
+++ b/src/DotNetBumper.Core/PostProcessors/PotentialFileEdit.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper.PostProcessors;
+
+internal sealed record PotentialFileEdit(int Line, int Column, string Text);

--- a/src/DotNetBumper.Core/PostProcessors/ProjectFile.cs
+++ b/src/DotNetBumper.Core/PostProcessors/ProjectFile.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper.PostProcessors;
+
+internal sealed record class ProjectFile(string FullPath, string RelativePath);

--- a/src/DotNetBumper.Core/PostProcessors/RemainingTargetFrameworksPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/RemainingTargetFrameworksPostProcessor.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+using GitIgnore = Ignore.Ignore;
+
+namespace MartinCostello.DotNetBumper.PostProcessors;
+
+internal sealed partial class RemainingTargetFrameworksPostProcessor(
+    IAnsiConsole console,
+    IOptions<UpgradeOptions> options,
+    ILogger<RemainingTargetFrameworksPostProcessor> logger) : PostProcessor(console, options, logger)
+{
+    protected override string Action => "Running tests";
+
+    protected override string InitialStatus => "Test project";
+
+    protected override async Task<ProcessingResult> PostProcessCoreAsync(
+        UpgradeInfo upgrade,
+        StatusContext context,
+        CancellationToken cancellationToken)
+    {
+        var gitignore = await LoadGitIgnoreAsync(cancellationToken);
+
+        var references = new Dictionary<(Uri Location, string RelativePath), List<(string Text, int Line)>>();
+
+        foreach (var path in Directory.EnumerateFiles(Options.ProjectPath, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = RelativeName(path).Replace('\\', '/');
+
+            if (gitignore?.IsIgnored(relativePath) is true)
+            {
+                continue;
+            }
+
+            int lineNumber = 0;
+            var fileReferences = new List<(string Text, int Line)>();
+
+            foreach (var line in await File.ReadAllLinesAsync(path, cancellationToken))
+            {
+                lineNumber++;
+
+                IList<Match> matches = line.MatchTargetFrameworkMonikers();
+
+                if (matches.Count is not 0)
+                {
+                    foreach (var match in matches)
+                    {
+                        if (match.ValueSpan.ToVersionFromTargetFramework() is { } version && version < upgrade.Channel)
+                        {
+                            fileReferences.Add((match.Value, lineNumber));
+                        }
+                    }
+                }
+            }
+
+            if (fileReferences.Count > 0)
+            {
+                references[(new(path), relativePath)] = fileReferences;
+            }
+        }
+
+        if (references.Count > 0)
+        {
+            var table = new Table
+            {
+                Title = new TableTitle("Remaining Target Framework References"),
+            };
+
+            table.AddColumn("Path");
+            table.AddColumn(new TableColumn("Line").RightAligned());
+            table.AddColumn(new TableColumn("Match").RightAligned());
+
+            foreach ((var key, var value) in references.OrderBy((p) => p.Key.RelativePath))
+            {
+                var first = value[0];
+                table.AddRow(Path(key.Location, key.RelativePath), Line(first.Line), Match(first.Text));
+
+                foreach (var item in value.Skip(1))
+                {
+                    table.AddRow(Empty(), Line(item.Line), Match(item.Text));
+                }
+            }
+
+            Console.Write(table);
+        }
+
+        return ProcessingResult.Success;
+
+        static Markup Empty() => new(string.Empty);
+        static Markup Line(int line) => new(line.ToString(CultureInfo.CurrentCulture));
+        static Markup Match(string text) => new($"[{Color.Yellow}]{text}[/]");
+
+        static Markup Path(Uri location, string relativePath)
+        {
+            string locationText = location.ToString().EscapeMarkup();
+            string pathText = relativePath.EscapeMarkup();
+
+            return new Markup($"[link={locationText}]{pathText}[/]");
+        }
+    }
+
+    private async Task<GitIgnore?> LoadGitIgnoreAsync(CancellationToken cancellationToken)
+    {
+        var gitDirectory = FileHelpers.FindDirectoryInProject(Options.ProjectPath, ".git");
+
+        if (gitDirectory is null)
+        {
+            return null;
+        }
+
+        var gitignore = Path.GetFullPath(Path.Combine(gitDirectory, "..", ".gitignore"));
+
+        if (!File.Exists(gitignore))
+        {
+            return null;
+        }
+
+        var ignore = new GitIgnore();
+        ignore.Add(".git");
+
+        foreach (var entry in await File.ReadAllLinesAsync(gitignore, cancellationToken))
+        {
+            ignore.Add(entry);
+        }
+
+        return ignore;
+    }
+}

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -112,6 +112,7 @@ public partial class ProjectUpgrader(
         {
             console.WriteLine();
             console.WriteWarningLine("One or more upgrade steps produced a warning.");
+            console.WriteLine();
         }
 
         if (result is ProcessingResult.Success or ProcessingResult.Warning)

--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -78,6 +78,7 @@ public static class ServiceCollectionExtensions
     private static IServiceCollection AddPostProcessors(this IServiceCollection services)
     {
         services.AddSingleton<IPostProcessor, DotNetTestPostProcessor>();
+        services.AddSingleton<IPostProcessor, RemainingTargetFrameworksPostProcessor>();
 
         return services;
     }

--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -78,7 +78,7 @@ public static class ServiceCollectionExtensions
     private static IServiceCollection AddPostProcessors(this IServiceCollection services)
     {
         services.AddSingleton<IPostProcessor, DotNetTestPostProcessor>();
-        services.AddSingleton<IPostProcessor, RemainingTargetFrameworksPostProcessor>();
+        services.AddSingleton<IPostProcessor, LeftoverReferencesPostProcessor>();
 
         return services;
     }

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -55,45 +55,24 @@ internal sealed partial class PackageVersionUpgrader(
 
     private static HiddenFile? TryHideGlobalJson(string path)
     {
-        var directory = new DirectoryInfo(path);
+        var globalJson = FileHelpers.FindFileInProject(path, "global.json");
 
-        do
+        if (globalJson != null)
         {
-            var globalJson = Directory.EnumerateFiles(directory.FullName, "global.json").FirstOrDefault();
-
-            if (globalJson != null)
-            {
-                return new HiddenFile(globalJson);
-            }
-
-            directory = directory.Parent;
+            return new HiddenFile(globalJson);
         }
-        while (directory is not null);
 
         return null;
     }
 
     private static HiddenFile? TryDotNetToolManifest(string path)
     {
-        var directory = new DirectoryInfo(path);
+        var toolManifest = FileHelpers.FindFileInProject(path, Path.Join(".config", "dotnet-tools.json"));
 
-        do
+        if (toolManifest != null)
         {
-            var configPath = Path.Combine(directory.FullName, ".config");
-
-            if (Directory.Exists(configPath))
-            {
-                var toolManifest = Directory.EnumerateFiles(configPath, "dotnet-tools.json").FirstOrDefault();
-
-                if (toolManifest != null)
-                {
-                    return new HiddenFile(toolManifest);
-                }
-            }
-
-            directory = directory.Parent;
+            return new HiddenFile(toolManifest);
         }
-        while (directory is not null);
 
         return null;
     }

--- a/src/DotNetBumper.Core/VersionExtensions.cs
+++ b/src/DotNetBumper.Core/VersionExtensions.cs
@@ -74,9 +74,9 @@ internal static partial class VersionExtensions
         return null;
     }
 
-    [GeneratedRegex($"(?!dot){TfmPattern}")]
+    [GeneratedRegex($"(?<!dot){TfmPattern}")]
     private static partial Regex ContainsTargetFrameworkMoniker();
 
-    [GeneratedRegex($"^{TfmPattern}")]
+    [GeneratedRegex($"^{TfmPattern}$")]
     private static partial Regex TargetFrameworkMoniker();
 }

--- a/src/DotNetBumper.Core/VersionExtensions.cs
+++ b/src/DotNetBumper.Core/VersionExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Text.RegularExpressions;
-using NuGet.Versioning;
 
 namespace MartinCostello.DotNetBumper;
 
@@ -24,9 +23,6 @@ internal static partial class VersionExtensions
 
     public static string ToTargetFramework(this Version version)
         => $"net{version.ToString(2)}";
-
-    public static string ToTargetFramework(this NuGetVersion version)
-        => $"net{version.Major}.{version.Minor}";
 
     public static Version? ToVersionFromLambdaRuntime(this string runtime)
         => runtime.AsSpan().ToVersionFromLambdaRuntime();

--- a/src/DotNetBumper.Core/VersionExtensions.cs
+++ b/src/DotNetBumper.Core/VersionExtensions.cs
@@ -8,11 +8,16 @@ namespace MartinCostello.DotNetBumper;
 
 internal static partial class VersionExtensions
 {
+    private const string TfmPattern = "net(coreapp)?[1-9]+\\.[0-9]{1}";
+
     public static bool IsTargetFrameworkMoniker(this string value)
         => TargetFrameworkMoniker().IsMatch(value);
 
     public static bool IsTargetFrameworkMoniker(this ReadOnlySpan<char> value)
         => TargetFrameworkMoniker().IsMatch(value);
+
+    public static MatchCollection MatchTargetFrameworkMonikers(this string value)
+        => ContainsTargetFrameworkMoniker().Matches(value);
 
     public static string ToLambdaRuntime(this Version version)
         => $"dotnet{version.ToString(1)}";
@@ -69,6 +74,9 @@ internal static partial class VersionExtensions
         return null;
     }
 
-    [GeneratedRegex("^net(coreapp)?[1-9]+\\.[0-9]{1}$")]
+    [GeneratedRegex($"(?!dot){TfmPattern}")]
+    private static partial Regex ContainsTargetFrameworkMoniker();
+
+    [GeneratedRegex($"^{TfmPattern}")]
     private static partial Regex TargetFrameworkMoniker();
 }

--- a/tests/DotNetBumper.Tests/BumperTestCase.cs
+++ b/tests/DotNetBumper.Tests/BumperTestCase.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Text;
-
 namespace MartinCostello.DotNetBumper;
 
 public sealed class BumperTestCase(

--- a/tests/DotNetBumper.Tests/DotNetBumper.Tests.csproj
+++ b/tests/DotNetBumper.Tests/DotNetBumper.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Spectre.Console.Testing" />
+    <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -37,6 +37,9 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
         // Arrange
         using var fixture = new UpgraderFixture(outputHelper);
 
+        fixture.Project.AddGitRepository();
+        await fixture.Project.AddGitIgnoreAsync();
+
         await fixture.Project.AddSolutionAsync("Project.sln");
         await fixture.Project.AddToolManifestAsync();
 

--- a/tests/DotNetBumper.Tests/JsonExtensionsTests.cs
+++ b/tests/DotNetBumper.Tests/JsonExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Text;
 using System.Text.Json.Nodes;
 
 namespace MartinCostello.DotNetBumper;

--- a/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Options;
+
+namespace MartinCostello.DotNetBumper.PostProcessors;
+
+public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task FindReferencesAsync_Finds_Target_Frameworks_Not_Matching_The_Upgrade()
+    {
+        // Arrange
+        string fileContents =
+            """
+            # Project
+
+            This is my project, it is great.
+
+            It currently supports the following target frameworks:
+
+            - net6.0
+            - net8.0
+
+            To build it, run the following command:
+
+            ```sh
+            dotnet publish --configuration Release --framework net6.0
+            ```
+
+            It supports AWS Lambda for the `dotnet6` runtimes and `dotnet8` runtimes.
+            """;
+
+        var fixture = new UpgraderFixture(outputHelper);
+        var channel = new Version(8, 0);
+
+        string relativePath = Path.Combine("README.md");
+        string fullPath = await fixture.Project.AddFileAsync(relativePath, fileContents);
+
+        var projectFile = new ProjectFile(fullPath, relativePath);
+
+        // Act
+        var actual = await LeftoverReferencesPostProcessor.FindReferencesAsync(projectFile, channel, CancellationToken.None);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.Count.ShouldBe(2);
+
+        actual[0].Line.ShouldBe(7);
+        actual[0].Column.ShouldBe(3);
+        actual[0].Text.ShouldBe("net6.0");
+
+        actual[1].Line.ShouldBe(13);
+        actual[1].Column.ShouldBe(52);
+        actual[1].Text.ShouldBe("net6.0");
+
+        // Arrange
+        relativePath = Path.Combine("version.txt");
+        fullPath = await fixture.Project.AddFileAsync(relativePath, "1.0.0");
+
+        projectFile = new ProjectFile(fullPath, relativePath);
+
+        // Act
+        actual = await LeftoverReferencesPostProcessor.FindReferencesAsync(projectFile, channel, CancellationToken.None);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task EnumerateProjectFilesAsync_When_No_Files()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.EnumerateProjectFilesAsync(CancellationToken.None).ToListAsync();
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task EnumerateProjectFilesAsync_When_No_Git_Directory()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        await fixture.Project.AddFileAsync("file.txt", "Hello, World!");
+        await fixture.Project.AddFileAsync("src/Program.cs", "Console.WriteLine(\"Hello, World!\"");
+        await fixture.Project.AddFileAsync("src/Project.csproj", "<Project/>");
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.EnumerateProjectFilesAsync(CancellationToken.None).ToListAsync();
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ShouldNotBeEmpty();
+        actual.Count.ShouldBe(3);
+
+        actual.ShouldContain((p) => p.RelativePath == "file.txt");
+        actual.ShouldContain((p) => p.RelativePath == "src/Program.cs");
+        actual.ShouldContain((p) => p.RelativePath == "src/Project.csproj");
+    }
+
+    [Theory]
+    [InlineData(false, new[] { "file.txt", "src/Program.cs", "src/Project.csproj", "src/bin/Project.dll", "src/bin/Project.pdb" })]
+    [InlineData(true, new[] { ".gitignore", "file.txt", "src/Program.cs", "src/Project.csproj" })]
+    public async Task EnumerateProjectFilesAsync_With_Git_Repository(
+        bool hasGitIgnore,
+        string[] expectedFiles)
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+        fixture.Project.AddGitRepository();
+
+        if (hasGitIgnore)
+        {
+            await fixture.Project.AddGitIgnoreAsync();
+        }
+
+        await fixture.Project.AddFileAsync("file.txt", "Hello, World!");
+        await fixture.Project.AddFileAsync("src/Program.cs", "Console.WriteLine(\"Hello, World!\"");
+        await fixture.Project.AddFileAsync("src/Project.csproj", "<Project/>");
+
+        await fixture.Project.AddFileAsync("src/bin/Project.dll", "10010101");
+        await fixture.Project.AddFileAsync("src/bin/Project.pdb", "0xdeadbeef");
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.EnumerateProjectFilesAsync(CancellationToken.None).ToListAsync();
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ShouldNotBeEmpty();
+        actual.Count.ShouldBe(expectedFiles.Length);
+
+        foreach (string fileName in expectedFiles)
+        {
+            actual.ShouldContain((p) => p.RelativePath == fileName, fileName);
+        }
+    }
+
+    [Fact]
+    public async Task PostProcessAsync_Succeeds()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+        fixture.Project.AddGitRepository();
+
+        await fixture.Project.AddFileAsync("file.txt", "Hello, World!");
+        await fixture.Project.AddFileAsync("src/Program.cs", "Console.WriteLine(\"Hello, World!\"");
+        await fixture.Project.AddFileAsync("src/Project.csproj", "<Project/>");
+
+        await fixture.Project.AddGitIgnoreAsync();
+        await fixture.Project.AddFileAsync("src/bin/Project.dll", "10010101");
+        await fixture.Project.AddFileAsync("src/bin/Project.pdb", "0xdeadbeef");
+
+        var target = CreateTarget(fixture);
+
+        var upgrade = new UpgradeInfo()
+        {
+            Channel = new(8, 0),
+            EndOfLife = DateOnly.MaxValue,
+            ReleaseType = DotNetReleaseType.Lts,
+            SdkVersion = new("8.0.100"),
+            SupportPhase = DotNetSupportPhase.Active,
+        };
+
+        // Act
+        var actual = await target.PostProcessAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actual.ShouldBe(ProcessingResult.Success);
+    }
+
+    private LeftoverReferencesPostProcessor CreateTarget(UpgraderFixture fixture)
+    {
+        var options = Options.Create(new UpgradeOptions() { ProjectPath = fixture.Project.DirectoryName });
+        var logger = outputHelper.ToLogger<LeftoverReferencesPostProcessor>();
+        return new LeftoverReferencesPostProcessor(fixture.Console, options, logger);
+    }
+}

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Text;
 using System.Xml.Linq;
 
 namespace MartinCostello.DotNetBumper;

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -40,6 +40,22 @@ internal sealed class Project : IDisposable
     public async Task<string> GetFileAsync(string path)
         => await File.ReadAllTextAsync(GetFilePath(path));
 
+    public async Task AddGitIgnoreAsync(string? gitignore = null)
+    {
+        gitignore ??=
+            """
+            bin
+            obj
+            """;
+
+        await AddFileAsync(".gitignore", gitignore);
+    }
+
+    public void AddGitRepository()
+    {
+        Directory.CreateDirectory(Path.Combine(DirectoryName, ".git"));
+    }
+
     public async Task<string> AddGlobalJsonAsync(string sdkVersion, string path = "global.json")
     {
         var globalJson = CreateGlobalJson(sdkVersion);

--- a/tests/DotNetBumper.Tests/ShouldlyExtensions.cs
+++ b/tests/DotNetBumper.Tests/ShouldlyExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Text;
-
 namespace MartinCostello.DotNetBumper;
 
 internal static class ShouldlyExtensions


### PR DESCRIPTION
After upgrading and testing a project, print any target frameworks that are found in files that didn't get updated to the console to draw the user's attention to any leftovers they may need to manually update.

- Files that are covered by the user's `.gitignore` file and not searched in.
- References that are found are linked to via the `vscode://` protocol.

![image](https://github.com/martincostello/dotnet-bumper/assets/1439341/e7b8ba56-3046-4b94-8219-731c2a82e90c)
