### PR TITLE
Add custom MSBuild logger

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,4 @@ updates:
   open-pull-requests-limit: 99
   ignore:
     - dependency-name: "Microsoft.Build.Utilities.Core"
+    - dependency-name: "System.Text.Json"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,5 @@ updates:
   reviewers:
     - "martincostello"
   open-pull-requests-limit: 99
+  ignore:
+    - dependency-name: "Microsoft.Build.Utilities.Core"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.2.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
@@ -24,6 +25,7 @@
     <PackageVersion Include="Spectre.Console.Testing" Version="0.48.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.2" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Spectre.Console.Testing" Version="0.48.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.2" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/DotNetBumper.sln
+++ b/DotNetBumper.sln
@@ -79,6 +79,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".config", ".config", "{1ADA
 		.config\dotnet-tools.json = .config\dotnet-tools.json
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetBumper.MSBuild", "src\DotNetBumper.MSBuild\DotNetBumper.MSBuild.csproj", "{82C41299-BA66-4D81-A40D-2362312BE449}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +99,10 @@ Global
 		{95DA702F-5B29-4004-A498-5FEB10783FCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{95DA702F-5B29-4004-A498-5FEB10783FCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{95DA702F-5B29-4004-A498-5FEB10783FCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82C41299-BA66-4D81-A40D-2362312BE449}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82C41299-BA66-4D81-A40D-2362312BE449}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82C41299-BA66-4D81-A40D-2362312BE449}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82C41299-BA66-4D81-A40D-2362312BE449}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,6 +116,7 @@ Global
 		{0E685C90-528A-4C24-BC8B-9090C80B8B76} = {1746AEA9-65C0-4D6A-9F9D-D32113149F43}
 		{CAE60372-3F77-4878-85D6-63AA223918BC} = {1746AEA9-65C0-4D6A-9F9D-D32113149F43}
 		{1ADAEDC3-EF73-492F-9B81-42DE296E4FBE} = {4CFD8621-B558-4A35-8780-E56A3C5F29CB}
+		{82C41299-BA66-4D81-A40D-2362312BE449} = {AD637F2E-02F5-49F6-BFA6-881E8C77DE61}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {164EB134-6EF3-479B-88ED-80863BBB2732}

--- a/src/DotNetBumper.Core/DotNetBumper.Core.csproj
+++ b/src/DotNetBumper.Core/DotNetBumper.Core.csproj
@@ -24,6 +24,9 @@
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DotNetBumper.MSBuild\DotNetBumper.MSBuild.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <InternalsVisibleTo Include="DotNetBumper.Tests" Key="$(StrongNamePublicKey)" />
   </ItemGroup>
 </Project>

--- a/src/DotNetBumper.Core/DotNetProcess.cs
+++ b/src/DotNetBumper.Core/DotNetProcess.cs
@@ -121,7 +121,7 @@ public sealed partial class DotNetProcess(ILogger<DotNetProcess> logger)
 
         if (logFilePath is not null)
         {
-            logEntries = await GetLogsAsync(logFilePath, cancellationToken);
+            logEntries = await GetLogsAsync(logFilePath, CancellationToken.None);
         }
 
         var result = new DotNetResult(
@@ -201,6 +201,12 @@ public sealed partial class DotNetProcess(ILogger<DotNetProcess> logger)
         try
         {
             using var stream = File.OpenRead(logFilePath);
+
+            if (stream.Length is 0)
+            {
+                return [];
+            }
+
             var logs = await JsonSerializer.DeserializeAsync<BumperLog>(stream, cancellationToken: cancellationToken);
             return logs?.Entries ?? [];
         }

--- a/src/DotNetBumper.Core/DotNetProcess.cs
+++ b/src/DotNetBumper.Core/DotNetProcess.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
+using System.Text.Json;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 
@@ -27,7 +28,67 @@ public sealed partial class DotNetProcess(ILogger<DotNetProcess> logger)
         IReadOnlyList<string> arguments,
         CancellationToken cancellationToken)
     {
-        using var process = StartDotNet(workingDirectory, arguments);
+        return await RunAsync(workingDirectory, null, arguments, cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs the specified dotnet command with a custom MSBuild logger.
+    /// </summary>
+    /// <param name="workingDirectory">The working directory for the process.</param>
+    /// <param name="arguments">The arguments to the command.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+    /// <returns>
+    /// A <see cref="Task{DotNetResult}"/> representing the asynchronous operation to run the command.
+    /// </returns>
+    public async Task<DotNetResult> RunWithLoggerAsync(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        using var temporaryFile = new TemporaryFile();
+        return await RunAsync(workingDirectory, temporaryFile.Path, arguments, cancellationToken);
+    }
+
+    private static Process StartDotNet(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        string? customLoggerFileName)
+    {
+        var startInfo = new ProcessStartInfo(DotNetExe.FullPathOrDefault(), arguments)
+        {
+            EnvironmentVariables =
+            {
+                ["DOTNET_ROLL_FORWARD"] = "Major",
+                ["MSBuildSDKsPath"] = null,
+                [BumperLogger.LoggerFilePathVariableName] = customLoggerFileName,
+            },
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            WorkingDirectory = workingDirectory,
+        };
+
+        // HACK See https://github.com/dotnet/msbuild/issues/6753
+        startInfo.EnvironmentVariables["MSBUILDDISABLENODEREUSE"] = "1";
+        startInfo.EnvironmentVariables["MSBUILDENSURESTDOUTFORTASKPROCESSES"] = "1";
+
+        return Process.Start(startInfo) ?? throw new InvalidOperationException($"Failed to start process for dotnet {arguments[0]}.");
+    }
+
+    private async Task<DotNetResult> RunAsync(
+        string workingDirectory,
+        string? logFilePath,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        if (logFilePath is not null)
+        {
+            string loggerPath = typeof(BumperLogger).Assembly.Location;
+            string customLogger = $"-logger:{loggerPath}";
+
+            arguments = [..arguments, customLogger];
+        }
+
+        using var process = StartDotNet(workingDirectory, arguments, logFilePath);
 
         // See https://stackoverflow.com/a/16326426/1064169 and
         // https://learn.microsoft.com/dotnet/api/system.diagnostics.processstartinfo.redirectstandardoutput.
@@ -56,11 +117,19 @@ public sealed partial class DotNetProcess(ILogger<DotNetProcess> logger)
 
         (string error, string output) = await readOutput;
 
+        IList<BumperLogEntry> logEntries = [];
+
+        if (logFilePath is not null)
+        {
+            logEntries = await GetLogsAsync(logFilePath, cancellationToken);
+        }
+
         var result = new DotNetResult(
             process.ExitCode == 0,
             process.ExitCode,
             output,
-            error);
+            error,
+            logEntries);
 
         if (!result.Success)
         {
@@ -125,25 +194,21 @@ public sealed partial class DotNetProcess(ILogger<DotNetProcess> logger)
         }
     }
 
-    private static Process StartDotNet(string workingDirectory, IReadOnlyList<string> arguments)
+    private async Task<IList<BumperLogEntry>> GetLogsAsync(
+        string logFilePath,
+        CancellationToken cancellationToken)
     {
-        var startInfo = new ProcessStartInfo(DotNetExe.FullPathOrDefault(), arguments)
+        try
         {
-            EnvironmentVariables =
-            {
-                ["DOTNET_ROLL_FORWARD"] = "Major",
-                ["MSBuildSDKsPath"] = null,
-            },
-            RedirectStandardError = true,
-            RedirectStandardOutput = true,
-            WorkingDirectory = workingDirectory,
-        };
-
-        // HACK See https://github.com/dotnet/msbuild/issues/6753
-        startInfo.EnvironmentVariables["MSBUILDDISABLENODEREUSE"] = "1";
-        startInfo.EnvironmentVariables["MSBUILDENSURESTDOUTFORTASKPROCESSES"] = "1";
-
-        return Process.Start(startInfo) ?? throw new InvalidOperationException($"Failed to start process for dotnet {arguments[0]}.");
+            using var stream = File.OpenRead(logFilePath);
+            var logs = await JsonSerializer.DeserializeAsync<BumperLog>(stream, cancellationToken: cancellationToken);
+            return logs?.Entries ?? [];
+        }
+        catch (Exception ex)
+        {
+            Log.GetMSBuildLogsFailed(logger, ex);
+            return [];
+        }
     }
 
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
@@ -187,5 +252,11 @@ public sealed partial class DotNetProcess(ILogger<DotNetProcess> logger)
             Level = LogLevel.Error,
             Message = "Command \"dotnet {Command}\" standard error: {Error}")]
         public static partial void CommandFailedError(ILogger logger, string command, string error);
+
+        [LoggerMessage(
+            EventId = 4,
+            Level = LogLevel.Warning,
+            Message = "Failed to read MSBuild logs.")]
+        public static partial void GetMSBuildLogsFailed(ILogger logger, Exception exception);
     }
 }

--- a/src/DotNetBumper.Core/DotNetResult.cs
+++ b/src/DotNetBumper.Core/DotNetResult.cs
@@ -10,8 +10,10 @@ namespace MartinCostello.DotNetBumper;
 /// <param name="ExitCode">The exit code from the process.</param>
 /// <param name="StandardOutput">The standard output from the process.</param>
 /// <param name="StandardError">The standard error from the process.</param>
+/// <param name="LogEntries">The errors and warnings logged by the process.</param>
 public sealed record DotNetResult(
     bool Success,
     int ExitCode,
     string StandardOutput,
-    string StandardError);
+    string StandardError,
+    IList<BumperLogEntry> LogEntries);

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -134,7 +134,7 @@ internal sealed partial class DotNetTestPostProcessor(
             foreach (var entries in group.GroupBy((p) => p.Id))
             {
                 var helpLink = entries
-                    .Where((p) => !string.IsNullOrEmpty(p.HelpLink))
+                    .Where((p) => !string.IsNullOrWhiteSpace(p.HelpLink))
                     .Select((p) => p.HelpLink)
                     .FirstOrDefault();
 

--- a/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
@@ -100,8 +100,8 @@ internal sealed partial class LeftoverReferencesPostProcessor(
             Title = new TableTitle($"Remaining References - {references.Sum((p) => p.Value.Count)}"),
         };
 
-        table.AddColumn("Location");
-        table.AddColumn("Match");
+        table.AddColumn("[bold]Location[/]");
+        table.AddColumn("[bold]Match[/]");
 
         foreach ((var file, var values) in references.OrderBy((p) => p.Key.RelativePath))
         {

--- a/src/DotNetBumper.Core/TemporaryFile.cs
+++ b/src/DotNetBumper.Core/TemporaryFile.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper;
+
+internal sealed class TemporaryFile : IDisposable
+{
+    public string Path { get; } = System.IO.Path.GetTempFileName();
+
+    public void Dispose()
+    {
+        try
+        {
+            File.Delete(Path);
+        }
+        catch (Exception)
+        {
+            // Ignore
+        }
+    }
+
+    public bool Exists() => File.Exists(Path);
+}

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -82,7 +82,7 @@ internal sealed partial class PackageVersionUpgrader(
 
     private async Task TryRestoreNuGetPackagesAsync(string directory, CancellationToken cancellationToken)
     {
-        var result = await dotnet.RunAsync(
+        var result = await dotnet.RunWithLoggerAsync(
             directory,
             ["restore", "--verbosity", "quiet"],
             cancellationToken);
@@ -207,24 +207,5 @@ internal sealed partial class PackageVersionUpgrader(
 
         public void Dispose()
             => File.Move(_temporary, _original, overwrite: true);
-    }
-
-    private sealed class TemporaryFile : IDisposable
-    {
-        public string Path { get; } = System.IO.Path.GetTempFileName();
-
-        public void Dispose()
-        {
-            try
-            {
-                File.Delete(Path);
-            }
-            catch (Exception)
-            {
-                // Ignore
-            }
-        }
-
-        public bool Exists() => File.Exists(Path);
     }
 }

--- a/src/DotNetBumper.MSBuild/BumperLog.cs
+++ b/src/DotNetBumper.MSBuild/BumperLog.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.DotNetBumper;
+
+/// <summary>
+/// A class representing the .NET Bumper log output for MSBuild.
+/// </summary>
+public sealed class BumperLog
+{
+    /// <summary>
+    /// Gets or sets the log entries.
+    /// </summary>
+    [JsonPropertyName("entries")]
+    public IList<BumperLogEntry> Entries { get; set; } = [];
+}

--- a/src/DotNetBumper.MSBuild/BumperLogEntry.cs
+++ b/src/DotNetBumper.MSBuild/BumperLogEntry.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.DotNetBumper;
+
+/// <summary>
+/// A class representing a log entry from .NET Bumper. This class cannot be inherited.
+/// </summary>
+public sealed class BumperLogEntry
+{
+    /// <summary>
+    /// Gets or sets the ID of the log entry.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message of the log entry.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of the log entry.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets a help link associated with the log entry.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("helpLink")]
+    public string? HelpLink { get; set; }
+}

--- a/src/DotNetBumper.MSBuild/BumperLogger.cs
+++ b/src/DotNetBumper.MSBuild/BumperLogger.cs
@@ -22,13 +22,21 @@ public sealed class BumperLogger : Logger
 
     /// <inheritdoc />
     public override void Initialize(IEventSource eventSource)
-    {
-        _logFilePath = Environment.GetEnvironmentVariable(LoggerFilePathVariableName);
+        => Initialize(eventSource, Environment.GetEnvironmentVariable(LoggerFilePathVariableName));
 
-        if (string.IsNullOrWhiteSpace(_logFilePath))
+    /// <summary>
+    /// Initializes the logger with the specified event source and log file path.
+    /// </summary>
+    /// <param name="eventSource">The <see cref="IEventSource"/> to use.</param>
+    /// <param name="logFilePath">The path of the log file to use.</param>
+    public void Initialize(IEventSource eventSource, string logFilePath)
+    {
+        if (string.IsNullOrWhiteSpace(logFilePath))
         {
             throw new InvalidOperationException($"The {LoggerFilePathVariableName} environment variable has no value set.");
         }
+
+        _logFilePath = logFilePath;
 
         eventSource.ErrorRaised += OnErrorRaised;
         eventSource.WarningRaised += OnWarningRaised;

--- a/src/DotNetBumper.MSBuild/BumperLogger.cs
+++ b/src/DotNetBumper.MSBuild/BumperLogger.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace MartinCostello.DotNetBumper;
+
+/// <summary>
+/// A class representing a custom .NET Bumper logger for MSBuild.
+/// </summary>
+public sealed class BumperLogger : Logger
+{
+    /// <summary>
+    /// The name of the environment variable that specifies the path to the log file.
+    /// </summary>
+    public const string LoggerFilePathVariableName = "MartinCostello_DotNetBumper_LogFilePath";
+
+    private readonly List<BumperLogEntry> _logEntries = [];
+    private string? _logFilePath;
+
+    /// <inheritdoc />
+    public override void Initialize(IEventSource eventSource)
+    {
+        _logFilePath = Environment.GetEnvironmentVariable(LoggerFilePathVariableName);
+
+        if (string.IsNullOrWhiteSpace(_logFilePath))
+        {
+            throw new InvalidOperationException($"The {LoggerFilePathVariableName} environment variable has no value set.");
+        }
+
+        eventSource.ErrorRaised += OnErrorRaised;
+        eventSource.WarningRaised += OnWarningRaised;
+    }
+
+    /// <inheritdoc />
+    public override void Shutdown()
+    {
+        try
+        {
+            var output = new BumperLog()
+            {
+                Entries = [.. _logEntries],
+            };
+
+            string json = JsonSerializer.Serialize(output);
+            File.WriteAllText(_logFilePath, json);
+        }
+        catch (Exception)
+        {
+            // Ignore to not break the whole MSBuild process
+        }
+
+        _logEntries.Clear();
+    }
+
+    private void OnWarningRaised(object sender, BuildWarningEventArgs args)
+    {
+        var entry = new BumperLogEntry()
+        {
+            HelpLink = args.HelpLink,
+            Id = args.Code,
+            Message = args.Message,
+            Type = "Warning",
+        };
+
+        _logEntries.Add(entry);
+    }
+
+    private void OnErrorRaised(object sender, BuildErrorEventArgs args)
+    {
+        var entry = new BumperLogEntry()
+        {
+            HelpLink = args.HelpLink,
+            Id = args.Code,
+            Message = args.Message,
+            Type = "Error",
+        };
+
+        _logEntries.Add(entry);
+    }
+}

--- a/src/DotNetBumper.MSBuild/DotNetBumper.MSBuild.csproj
+++ b/src/DotNetBumper.MSBuild/DotNetBumper.MSBuild.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>A library containing the MSBuild integration for .NET Bumper.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+    <OutputType>Library</OutputType>
+    <PackageId>MartinCostello.DotNetBumper.MSBuild</PackageId>
+    <RootNamespace>MartinCostello.DotNetBumper</RootNamespace>
+    <Summary>$(Description)</Summary>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Title>$(PackageId)</Title>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="DotNetBumper.Tests" Key="$(StrongNamePublicKey)" />
+  </ItemGroup>
+</Project>

--- a/tests/DotNetBumper.Tests/BumperLoggerTests.cs
+++ b/tests/DotNetBumper.Tests/BumperLoggerTests.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Microsoft.Build.Framework;
+using NSubstitute;
+
+namespace MartinCostello.DotNetBumper;
+
+public class BumperLoggerTests
+{
+    [Fact]
+    public async Task BumperLogger_Logs_To_Json_File()
+    {
+        // Arrange
+        var eventSource = Substitute.For<IEventSource>();
+        var logFilePath = Path.GetTempFileName();
+
+        var logger = new BumperLogger();
+
+        // Act
+        logger.Initialize(eventSource, logFilePath);
+        logger.Shutdown();
+
+        // Assert
+        File.Exists(logFilePath).ShouldBeTrue();
+
+        using var stream = File.OpenRead(logFilePath);
+        var actual = await JsonSerializer.DeserializeAsync<BumperLog>(stream);
+
+        actual.ShouldNotBeNull();
+        actual.Entries.ShouldNotBeNull();
+        actual.Entries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task BumperLogger_Logs_Errors_And_Warnings_To_Json_File()
+    {
+        // Arrange
+        var warning = new BuildWarningEventArgs(
+            "Tests",
+            "MSB0001",
+            "Test.cs",
+            1,
+            1,
+            1,
+            1,
+            "Test warning",
+            "Test",
+            "Test");
+
+        var error = new BuildErrorEventArgs(
+            "Tests",
+            "MSB0002",
+            "Test.cs",
+            1,
+            1,
+            1,
+            1,
+            "Test error",
+            "Test",
+            "Test");
+
+        var eventSource = Substitute.For<IEventSource>();
+
+        var logFilePath = Path.GetTempFileName();
+        var logger = new BumperLogger();
+
+        // Act
+        logger.Initialize(eventSource, logFilePath);
+
+        eventSource.WarningRaised += Raise.Event<BuildWarningEventHandler>(this, warning);
+        eventSource.ErrorRaised += Raise.Event<BuildErrorEventHandler>(this, error);
+
+        logger.Shutdown();
+
+        // Assert
+        File.Exists(logFilePath).ShouldBeTrue();
+
+        using var stream = File.OpenRead(logFilePath);
+        var actual = await JsonSerializer.DeserializeAsync<BumperLog>(stream);
+
+        actual.ShouldNotBeNull();
+        actual.Entries.ShouldNotBeNull();
+        actual.Entries.Count.ShouldBe(2);
+
+        actual.Entries[0].Type.ShouldBe("Warning");
+        actual.Entries[0].Id.ShouldBe("MSB0001");
+        actual.Entries[0].Message.ShouldBe("Test warning");
+
+        actual.Entries[1].Type.ShouldBe("Error");
+        actual.Entries[1].Id.ShouldBe("MSB0002");
+        actual.Entries[1].Message.ShouldBe("Test error");
+    }
+
+    [Fact]
+    public void BumperLogger_Logs_To_Console()
+    {
+        // Arrange
+        var eventSource = Substitute.For<IEventSource>();
+        var logFilePath = string.Empty;
+
+        var logger = new BumperLogger();
+
+        // Act and Assert
+        Should.Throw<InvalidOperationException>(
+            () => logger.Initialize(eventSource, logFilePath));
+    }
+}

--- a/tests/DotNetBumper.Tests/JsonExtensionsTests.cs
+++ b/tests/DotNetBumper.Tests/JsonExtensionsTests.cs
@@ -10,7 +10,7 @@ public static class JsonExtensionsTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public static async void File_Encoding_Is_Retained(bool writeBom)
+    public static async Task File_Encoding_Is_Retained(bool writeBom)
     {
         // Arrange
         var path = WriteJsonToFile(writeBom);
@@ -33,7 +33,7 @@ public static class JsonExtensionsTests
 
         using var stream = File.OpenRead(path);
 
-        var parsed = JsonNode.Parse(stream)!.AsObject();
+        var parsed = (await JsonNode.ParseAsync(stream))!.AsObject();
         parsed["foo"]!.GetValue<string>().ShouldBe("bar");
     }
 


### PR DESCRIPTION
Log MSBuild errors from `dotnet test` and `dotnet restore` to the console as a table grouped by error code.

Contributes to #55.

![image](https://github.com/martincostello/dotnet-bumper/assets/1439341/e9a9886e-02ca-4b72-951a-306566e0f264)
