### PR TITLE
Preserve JSON and XML new line characters

### DIFF
--- a/src/DotNetBumper.Core/JsonExtensions.cs
+++ b/src/DotNetBumper.Core/JsonExtensions.cs
@@ -9,8 +9,6 @@ namespace MartinCostello.DotNetBumper;
 
 internal static class JsonExtensions
 {
-    private static readonly byte[] NewLineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
-
     public static bool TryGetStringProperty(
         this JsonObject node,
         string propertyName,
@@ -45,23 +43,56 @@ internal static class JsonExtensions
         JsonWriterOptions options,
         CancellationToken cancellationToken)
     {
-        using var stream = FileHelpers.OpenWrite(path, out var metadata);
-
-        if (metadata.Encoding.Preamble.Length > 0)
+        FileMetadata metadata;
+        using (var stream = FileHelpers.OpenWrite(path, out metadata))
         {
-            stream.Write(metadata.Encoding.Preamble);
+            if (metadata.Encoding.Preamble.Length > 0)
+            {
+                stream.Write(metadata.Encoding.Preamble);
+            }
+
+            using var writer = new Utf8JsonWriter(stream, options);
+
+            node.WriteTo(writer);
+
+            await writer.FlushAsync(cancellationToken);
+
+            // The edit may have caused the file to shrink, so truncate it to the new length
+            stream.SetLength(stream.Position);
         }
 
-        // JsonWriterOptions does not currently support a custom NewLine character.
+        // JsonWriterOptions does not currently support a custom NewLine character,
+        // so fix up the line endings manually for by re-writing with the original.
         // See https://github.com/dotnet/runtime/issues/84117.
-        using var writer = new Utf8JsonWriter(stream, options);
+        await FixupLineEndingsAsync(path, metadata, cancellationToken);
+    }
 
-        node.WriteTo(writer);
+    private static async Task FixupLineEndingsAsync(string path, FileMetadata metadata, CancellationToken cancellationToken)
+    {
+        using var buffered = new MemoryStream();
 
-        await writer.FlushAsync(cancellationToken);
-        await stream.WriteAsync(NewLineBytes, cancellationToken);
+        using (var input = File.OpenRead(path))
+        using (var reader = new StreamReader(input, metadata.Encoding))
+        using (var writer = new StreamWriter(buffered, metadata.Encoding, leaveOpen: true))
+        {
+            writer.NewLine = metadata.NewLine;
 
-        // The edit may have caused the file to shrink, so truncate it to the new length
-        stream.SetLength(stream.Position);
+            while (await reader.ReadLineAsync(cancellationToken) is { } line)
+            {
+                await writer.WriteAsync(line);
+                await writer.WriteLineAsync();
+            }
+
+            await writer.FlushAsync(cancellationToken);
+        }
+
+        buffered.Seek(0, SeekOrigin.Begin);
+
+        using var output = File.OpenWrite(path);
+
+        await buffered.CopyToAsync(output, cancellationToken);
+        await buffered.FlushAsync(cancellationToken);
+
+        output.SetLength(output.Position);
     }
 }

--- a/src/DotNetBumper.Core/JsonExtensions.cs
+++ b/src/DotNetBumper.Core/JsonExtensions.cs
@@ -52,7 +52,8 @@ internal static class JsonExtensions
             stream.Write(metadata.Encoding.Preamble);
         }
 
-        // JsonWriterOptions does not currently support a custom NewLine character
+        // JsonWriterOptions does not currently support a custom NewLine character.
+        // See https://github.com/dotnet/runtime/issues/84117.
         using var writer = new Utf8JsonWriter(stream, options);
 
         node.WriteTo(writer);

--- a/src/DotNetBumper.Core/JsonHelpers.cs
+++ b/src/DotNetBumper.Core/JsonHelpers.cs
@@ -12,7 +12,7 @@ internal static class JsonHelpers
     internal static readonly JsonDocumentOptions DocumentOptions = new()
     {
         AllowTrailingCommas = true,
-        CommentHandling = JsonCommentHandling.Skip,
+        CommentHandling = JsonCommentHandling.Skip, // See https://github.com/dotnet/runtime/issues/98865
     };
 
     public static bool TryLoadObject(string path, [NotNullWhen(true)] out JsonObject? root)

--- a/tests/DotNetBumper.Tests/Upgraders/AwsLambdaToolsUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/AwsLambdaToolsUpgraderTests.cs
@@ -187,7 +187,7 @@ public class AwsLambdaToolsUpgraderTests(ITestOutputHelper outputHelper)
         ];
 
         string fileContents = string.Join(newLine, originalLines) + newLine;
-        string expectedContent = string.Join(Environment.NewLine, expectedLines) + Environment.NewLine;
+        string expectedContent = string.Join(newLine, expectedLines) + newLine;
 
         using var fixture = new UpgraderFixture(outputHelper);
 

--- a/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
@@ -148,6 +148,7 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
         [
             "<Project Sdk=\"Microsoft.NET.Sdk\">",
             "  <PropertyGroup>",
+            "    <!-- This is a comment -->",
             "    <TargetFramework>net6.0</TargetFramework>",
             "  </PropertyGroup>",
             "</Project>",
@@ -157,13 +158,14 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
         [
             "<Project Sdk=\"Microsoft.NET.Sdk\">",
             "  <PropertyGroup>",
+            "    <!-- This is a comment -->",
             "    <TargetFramework>net10.0</TargetFramework>",
             "  </PropertyGroup>",
             "</Project>",
         ];
 
         string fileContents = string.Join(newLine, originalLines) + newLine;
-        string expectedContent = string.Join(Environment.NewLine, expectedLines) + Environment.NewLine;
+        string expectedContent = string.Join(newLine, expectedLines) + newLine;
 
         using var fixture = new UpgraderFixture(outputHelper);
 

--- a/tests/DotNetBumper.Tests/Upgraders/VisualStudioCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/VisualStudioCodeUpgraderTests.cs
@@ -259,7 +259,7 @@ public class VisualStudioCodeUpgraderTests(ITestOutputHelper outputHelper)
         ];
 
         string fileContents = string.Join(newLine, originalLines) + newLine;
-        string expectedContent = string.Join(Environment.NewLine, expectedLines) + Environment.NewLine;
+        string expectedContent = string.Join(newLine, expectedLines) + newLine;
 
         using var fixture = new UpgraderFixture(outputHelper);
 

--- a/tests/DotNetBumper.Tests/Upgraders/VisualStudioComponentUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/VisualStudioComponentUpgraderTests.cs
@@ -169,7 +169,7 @@ public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
         ];
 
         string fileContents = string.Join(newLine, originalLines) + newLine;
-        string expectedContent = string.Join(Environment.NewLine, expectedLines) + Environment.NewLine;
+        string expectedContent = string.Join(newLine, expectedLines) + newLine;
 
         using var fixture = new UpgraderFixture(outputHelper);
 


### PR DESCRIPTION
- Re-write JSON edits to preserve the original line endings.
- Fix XML updates for project files to preserve line endings.

Resolves #30.
