### PR TITLE
Add .NET breaking changes link

### DIFF
--- a/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
+++ b/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
@@ -14,12 +14,14 @@ public static class IAnsiConsoleExtensions
     /// Writes a disclaimer to the console.
     /// </summary>
     /// <param name="console">The <see cref="IAnsiConsole"/> to use.</param>
-    public static void WriteDisclaimer(this IAnsiConsole console)
+    /// <param name="channel">The version of .NET that the project was upgraded to.</param>
+    public static void WriteDisclaimer(this IAnsiConsole console, Version channel)
     {
         string[] disclaimer =
         [
             $"{Emoji.Known.Megaphone} .NET Bumper upgrades are made on a best-effort basis.",
             $"{Emoji.Known.MagnifyingGlassTiltedRight} You should [bold]always[/] review the changes and test your project to validate the upgrade.",
+            $"{Emoji.Known.OpenBook} [link={BreakingChangesLink(channel)}]Breaking changes in .NET {channel.Major}[/]",
         ];
 
         var panel = new Panel(string.Join(Environment.NewLine, disclaimer))
@@ -30,6 +32,9 @@ public static class IAnsiConsoleExtensions
         };
 
         console.Write(panel);
+
+        static string BreakingChangesLink(Version channel)
+            => $"https://learn.microsoft.com/dotnet/core/compatibility/{channel}";
     }
 
     /// <summary>

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -153,7 +153,7 @@ public partial class ProjectUpgrader(
         {
             console.MarkupLine($"[aqua]{name}[/] upgrade to [white on purple].NET {upgrade.Channel}[/] [green]successful[/]! :rocket:");
             console.WriteLine();
-            console.WriteDisclaimer();
+            console.WriteDisclaimer(upgrade.Channel);
         }
         else if (result is ProcessingResult.None)
         {


### PR DESCRIPTION
Add a link to the _"Breaking changes in .NET X"_ documentation in the disclaimer.

![image](https://github.com/martincostello/dotnet-bumper/assets/1439341/da50153a-d1a0-4e88-90f2-613b565be5e2)

Relates to #38.
