### PR TITLE
Miscellaneous bug fixes

### DIFF
--- a/src/DotNetBumper.Core/EnvironmentHelpers.cs
+++ b/src/DotNetBumper.Core/EnvironmentHelpers.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper;
+
+internal static class EnvironmentHelpers
+{
+    public static bool IsGitHubActions { get; } = Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is "true";
+}

--- a/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
+++ b/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
@@ -17,23 +17,35 @@ public static class IAnsiConsoleExtensions
     /// <param name="channel">The version of .NET that the project was upgraded to.</param>
     public static void WriteDisclaimer(this IAnsiConsole console, Version channel)
     {
-        string[] disclaimer =
+        List<string> disclaimer =
         [
             $"{Emoji.Known.Megaphone} .NET Bumper upgrades are made on a best-effort basis.",
             $"{Emoji.Known.MagnifyingGlassTiltedRight} You should [bold]always[/] review the changes and test your project to validate the upgrade.",
-            $"{Emoji.Known.OpenBook} [link={BreakingChangesLink(channel)}]Breaking changes in .NET {channel.Major}[/]",
         ];
+
+        var breakingChangesEmoji = Emoji.Known.OpenBook;
+        var breakingChangesTitle = $"Breaking changes in .NET {channel.Major}";
+        var breakingChangesUrl = BreakingChangesUrl(channel);
+
+        if (EnvironmentHelpers.IsGitHubActions)
+        {
+            disclaimer.Add($"{breakingChangesEmoji} [bold]{breakingChangesTitle}/] - {breakingChangesUrl}");
+        }
+        else
+        {
+            disclaimer.Add($"{breakingChangesEmoji} [link={breakingChangesUrl}]{breakingChangesTitle}[/]");
+        }
 
         var panel = new Panel(string.Join(Environment.NewLine, disclaimer))
         {
             Border = BoxBorder.Rounded,
             Expand = true,
-            Header = new PanelHeader("[yellow]Disclaimer[/]", Justify.Center),
+            Header = new PanelHeader($"[{Color.Yellow}]Disclaimer[/]", Justify.Center),
         };
 
         console.Write(panel);
 
-        static string BreakingChangesLink(Version channel)
+        static string BreakingChangesUrl(Version channel)
             => $"https://learn.microsoft.com/dotnet/core/compatibility/{channel}";
     }
 
@@ -47,7 +59,21 @@ public static class IAnsiConsoleExtensions
     {
         var eolUtc = upgrade.EndOfLife.GetValueOrDefault().ToDateTime(TimeOnly.MinValue);
         console.WriteWarningLine($"Support for .NET {upgrade.Channel} ends in {daysRemaining:N0} days on {eolUtc:D}.");
-        console.WriteWarningLine("See [link=https://dotnet.microsoft.com/platform/support/policy/dotnet-core].NET and .NET Core Support Policy[/] for more information.");
+
+        var supportPolicyTitle = ".NET and .NET Core Support Policy";
+        var supportPolicyUrl = SupportPolicyUrl(upgrade.Channel);
+
+        if (EnvironmentHelpers.IsGitHubActions)
+        {
+            console.WriteWarningLine($"See [bold]{supportPolicyTitle}[/] for more information: {supportPolicyUrl}");
+        }
+        else
+        {
+            console.WriteWarningLine($"See [link={supportPolicyUrl}]{supportPolicyTitle}[/] for more information.");
+        }
+
+        static string SupportPolicyUrl(Version channel)
+            => $"https://learn.microsoft.com/dotnet/core/compatibility/{channel}";
     }
 
     /// <summary>

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -187,7 +187,7 @@ internal sealed partial class DotNetTestPostProcessor(
 
                 string idMarkup = entries.Key.EscapeMarkup();
 
-                if (!string.IsNullOrEmpty(helpLink))
+                if (!string.IsNullOrEmpty(helpLink) && !EnvironmentHelpers.IsGitHubActions)
                 {
                     string linkEscaped = helpLink.EscapeMarkup();
                     idMarkup = $"[link={linkEscaped}]{idMarkup}[/]";

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -19,7 +19,7 @@ internal sealed partial class DotNetTestPostProcessor(
 
     protected override Style? SpinnerStyle { get; } = Style.Parse("green");
 
-    protected override string StatusColor => "teal";
+    protected override Color StatusColor => Color.Teal;
 
     public override async Task<ProcessingResult> PostProcessAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
@@ -116,10 +116,15 @@ internal sealed partial class LeftoverReferencesPostProcessor(
 
         static Markup Location(ProjectFile file, PotentialFileEdit edit)
         {
-            string location = VisualStudioCodeLink(file, edit);
             string path = $"{file.RelativePath.EscapeMarkup()}:{edit.Line}";
 
-            return new Markup($"[link={location}]{path}[/]");
+            if (!EnvironmentHelpers.IsGitHubActions)
+            {
+                string location = VisualStudioCodeLink(file, edit);
+                path = $"[link={location}]{path}[/]";
+            }
+
+            return new Markup(path);
         }
 
         static Markup Match(string text) => new($"[{Color.Yellow}]{text.EscapeMarkup()}[/]");

--- a/src/DotNetBumper.Core/UpgradeTask.cs
+++ b/src/DotNetBumper.Core/UpgradeTask.cs
@@ -22,7 +22,7 @@ internal abstract class UpgradeTask(
 
     protected abstract string Action { get; }
 
-    protected virtual string ActionColor => "grey";
+    protected virtual Color ActionColor { get; } = EnvironmentHelpers.IsGitHubActions ? Color.Teal : Color.Grey;
 
     protected abstract string InitialStatus { get; }
 
@@ -30,7 +30,7 @@ internal abstract class UpgradeTask(
 
     protected virtual Style? SpinnerStyle => null;
 
-    protected virtual string StatusColor => "silver";
+    protected virtual Color StatusColor => Color.Silver;
 
     protected string RelativeName(string path)
         => ProjectHelpers.RelativeName(Options.ProjectPath, path);

--- a/src/DotNetBumper.MSBuild/BumperLogger.cs
+++ b/src/DotNetBumper.MSBuild/BumperLogger.cs
@@ -65,12 +65,14 @@ public sealed class BumperLogger : Logger
         _logEntries.Clear();
     }
 
+    private static string Code(string? code) => code ?? UnknownId;
+
     private void OnWarningRaised(object sender, BuildWarningEventArgs args)
     {
         var entry = new BumperLogEntry()
         {
             HelpLink = args.HelpLink,
-            Id = args.Code ?? UnknownId,
+            Id = Code(args.Code),
             Message = args.Message,
             Type = "Warning",
         };
@@ -83,7 +85,7 @@ public sealed class BumperLogger : Logger
         var entry = new BumperLogEntry()
         {
             HelpLink = args.HelpLink,
-            Id = args.Code ?? UnknownId,
+            Id = Code(args.Code),
             Message = args.Message,
             Type = "Error",
         };

--- a/src/DotNetBumper.MSBuild/BumperLogger.cs
+++ b/src/DotNetBumper.MSBuild/BumperLogger.cs
@@ -17,6 +17,8 @@ public sealed class BumperLogger : Logger
     /// </summary>
     public const string LoggerFilePathVariableName = "MartinCostello_DotNetBumper_LogFilePath";
 
+    private const string UnknownId = "Unknown";
+
     private readonly List<BumperLogEntry> _logEntries = [];
     private string? _logFilePath;
 
@@ -68,7 +70,7 @@ public sealed class BumperLogger : Logger
         var entry = new BumperLogEntry()
         {
             HelpLink = args.HelpLink,
-            Id = args.Code,
+            Id = args.Code ?? UnknownId,
             Message = args.Message,
             Type = "Warning",
         };
@@ -81,7 +83,7 @@ public sealed class BumperLogger : Logger
         var entry = new BumperLogEntry()
         {
             HelpLink = args.HelpLink,
-            Id = args.Code,
+            Id = args.Code ?? UnknownId,
             Message = args.Message,
             Type = "Error",
         };

--- a/tests/DotNetBumper.Tests/DotNetBumper.Tests.csproj
+++ b/tests/DotNetBumper.Tests/DotNetBumper.Tests.csproj
@@ -37,6 +37,6 @@
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[xunit.*]*</Exclude>
     <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
-    <Threshold>75</Threshold>
+    <Threshold>90,75,90</Threshold>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Bug fixes after automated run with GitHub Actions ([logs](https://github.com/martincostello/github-automation/actions/runs/8029905705)):

- Handle an MSBuild error/warning having no associated code.
- Do not render `[link={url}]{text}[/]` markup in GitHub Actions as it does not render correctly.
- `grey` doesn't have enough contrast in GitHub Actions, so use `teal`.
- Refactor to use `Color` instead of strings for progress colours.
