### PR TITLE
Ignore some file types when finding references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0" />
+    <PackageVersion Include="MimeTypes" Version="2.4.1" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="NuGet.Versioning" Version="6.9.1" />
     <PackageVersion Include="ReportGenerator" Version="5.2.1" />

--- a/src/DotNetBumper.Core/DotNetBumper.Core.csproj
+++ b/src/DotNetBumper.Core/DotNetBumper.Core.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="MimeTypes" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="YamlDotNet" />

--- a/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
@@ -106,12 +106,7 @@ internal sealed partial class LeftoverReferencesPostProcessor(
 
         var segments = mimeType.Split('/', StringSplitOptions.RemoveEmptyEntries);
 
-        if (segments.Length < 1)
-        {
-            return false;
-        }
-
-        return segments[0] switch
+        return segments.Length >= 1 && segments[0] switch
         {
             "application" or "font" or "image" or "video" => true,
             _ => false,

--- a/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
@@ -16,6 +16,11 @@ internal sealed partial class LeftoverReferencesPostProcessor(
     IOptions<UpgradeOptions> options,
     ILogger<LeftoverReferencesPostProcessor> logger) : PostProcessor(console, environment, options, logger)
 {
+    static LeftoverReferencesPostProcessor()
+    {
+        MimeTypes.FallbackMimeType = string.Empty;
+    }
+
     protected override string Action => "Find leftover references";
 
     protected override string InitialStatus => "Search files";
@@ -56,7 +61,7 @@ internal sealed partial class LeftoverReferencesPostProcessor(
 
             var relativePath = RelativeName(path).Replace('\\', '/');
 
-            if (gitignore?.IsIgnored(relativePath) is true)
+            if (gitignore?.IsIgnored(relativePath) is true || IsIgnoredFileType(path))
             {
                 continue;
             }
@@ -90,6 +95,27 @@ internal sealed partial class LeftoverReferencesPostProcessor(
         }
 
         return ProcessingResult.Success;
+    }
+
+    private static bool IsIgnoredFileType(string path)
+    {
+        if (!MimeTypes.TryGetMimeType(path, out var mimeType))
+        {
+            return false;
+        }
+
+        var segments = mimeType.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        if (segments.Length < 1)
+        {
+            return false;
+        }
+
+        return segments[0] switch
+        {
+            "application" or "font" or "image" or "video" => true,
+            _ => false,
+        };
     }
 
     private void RenderTable(Dictionary<ProjectFile, List<PotentialFileEdit>> references)

--- a/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
@@ -109,7 +109,7 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
     }
 
     [Theory]
-    [InlineData(false, new[] { "file.txt", "src/Program.cs", "src/Project.csproj", "src/bin/Project.dll", "src/bin/Project.pdb" })]
+    [InlineData(false, new[] { ".idea/config", ".vs/config", "file.txt", "src/Program.cs", "src/Project.csproj" })]
     [InlineData(true, new[] { ".gitignore", "file.txt", "src/Program.cs", "src/Project.csproj" })]
     public async Task EnumerateProjectFilesAsync_With_Git_Repository(
         bool hasGitIgnore,
@@ -124,7 +124,13 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
             await fixture.Project.AddGitIgnoreAsync();
         }
 
+        await fixture.Project.AddFileAsync("demo.mp4", "<A video>");
         await fixture.Project.AddFileAsync("file.txt", "Hello, World!");
+        await fixture.Project.AddFileAsync("logo.png", "<An image>");
+
+        await fixture.Project.AddFileAsync(".idea/config", "<Some Rider config>");
+        await fixture.Project.AddFileAsync(".vs/config", "<Some Visual Studio config>");
+
         await fixture.Project.AddFileAsync("src/Program.cs", "Console.WriteLine(\"Hello, World!\"");
         await fixture.Project.AddFileAsync("src/Project.csproj", "<Project/>");
 

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -44,6 +44,8 @@ internal sealed class Project : IDisposable
     {
         gitignore ??=
             """
+            .idea
+            .vs
             bin
             obj
             """;


### PR DESCRIPTION
Use `MimeTypes` to ignore searching through files that appear to be binary, font, image or video.
