### PR TITLE
Fix issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ PublishProfiles
 *.sln.docstates
 *.sln.ide
 *.suo
+*.tmp
 *.user

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -112,7 +112,7 @@ internal sealed partial class DotNetTestPostProcessor(
     }
 
     private async Task<DotNetResult> RunTestsAsync(
-        IReadOnlyList<string> projects,
+        List<string> projects,
         StatusContext context,
         CancellationToken cancellationToken)
     {

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -83,7 +83,7 @@ internal sealed partial class DotNetTestPostProcessor(
 
             Console.WriteLine();
 
-            if (result.TestLogs?.Summary.Count > 0)
+            if (result.TestLogs?.Summary.Sum((p) => p.Value.Count) > 0)
             {
                 WriteTestResults(result.TestLogs);
             }


### PR DESCRIPTION
- Do not output a test result table if there are no outcomes to report for a container (e.g. `Test Run Aborted`).
- Copy the custom test adapter to its own directory to prevent other files related to the tool causing issues with `dotnet test`.
- Ignore `*.tmp` files.
- Change type to `List<string>` to resolve `CA1859` warning in .NET 9.
