### PR TITLE
Update .NET test SDK

### DIFF
--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -124,13 +124,18 @@ internal sealed partial class PackageVersionUpgrader(
             arguments.Add("--pre-release:Always");
         }
 
-        string[] packages =
+        List<string> packages =
         [
             "Microsoft.AspNetCore.",
             "Microsoft.EntityFrameworkCore.",
             "Microsoft.Extensions.",
             "System.Text.Json",
         ];
+
+        if (Options.UpgradeType is not UpgradeType.Preview)
+        {
+            packages.Add("Microsoft.NET.Test.Sdk");
+        }
 
         foreach (string package in packages)
         {


### PR DESCRIPTION
Also include the .NET test SDK when upgrading NuGet packages.

Previews are excluded as they don't typically need to use a pre-release version of that package.
