### PR TITLE
Fix TFM update handling issues

### DIFF
--- a/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
@@ -34,10 +34,16 @@ internal sealed partial class LeftoverReferencesPostProcessor(
     {
         int lineNumber = 0;
         var result = new List<PotentialFileEdit>();
+        var expectedTfm = channel.ToTargetFramework();
 
         foreach (var line in await File.ReadAllLinesAsync(file.FullPath, cancellationToken))
         {
             lineNumber++;
+
+            if (line.Contains(expectedTfm, StringComparison.Ordinal))
+            {
+                continue;
+            }
 
             IList<Match> matches = line.MatchTargetFrameworkMonikers();
 

--- a/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
@@ -105,6 +105,7 @@ internal sealed partial class TargetFrameworkUpgrader(
         var remaining = property;
 
         int validTfms = 0;
+        int updateableTfms = 0;
 
         while (!remaining.IsEmpty)
         {
@@ -115,14 +116,22 @@ internal sealed partial class TargetFrameworkUpgrader(
             {
                 if (!part.IsTargetFrameworkMoniker())
                 {
-                    return false;
+                    if (!part.StartsWith("net4") &&
+                        !part.StartsWith("netstandard"))
+                    {
+                        return false;
+                    }
                 }
-
-                var version = part.ToVersionFromTargetFramework();
-
-                if (version is null || version >= channel)
+                else
                 {
-                    return false;
+                    var version = part.ToVersionFromTargetFramework();
+
+                    if (version is null || version >= channel)
+                    {
+                        return false;
+                    }
+
+                    updateableTfms++;
                 }
 
                 validTfms++;
@@ -137,7 +146,7 @@ internal sealed partial class TargetFrameworkUpgrader(
         }
 
         append = validTfms > 1;
-        return validTfms > 0;
+        return updateableTfms > 0;
     }
 
     private async Task<(XDocument? Project, FileMetadata? Metadata)> LoadProjectAsync(

--- a/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
@@ -29,6 +29,8 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
             ```
 
             It supports AWS Lambda for the `dotnet6` runtimes and `dotnet8` runtimes.
+
+            It also multi-targets `net6.0` and `net8.0`.
             """;
 
         var fixture = new UpgraderFixture(outputHelper);

--- a/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
@@ -24,6 +24,7 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
                     testCases.Add(channel, fileName, hasByteOrderMark, "TargetFramework", "net6.0", $"net{channel}");
                     testCases.Add(channel, fileName, hasByteOrderMark, "TargetFrameworks", "net5.0;net6.0", $"net5.0;net6.0;net{channel}");
                     testCases.Add(channel, fileName, hasByteOrderMark, "TargetFrameworks", "net5.0;;;;net6.0", $"net5.0;;;;net6.0;net{channel}");
+                    testCases.Add(channel, fileName, hasByteOrderMark, "TargetFrameworks", "netstandard2.0;net462;net6.0", $"netstandard2.0;net462;net6.0;net{channel}");
                 }
             }
         }
@@ -115,6 +116,7 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
     [InlineData("<Project><PropertyGroup><SomeProperty>;;</SomeProperty></PropertyGroup></Project>", ProcessingResult.None)]
     [InlineData("<Project><PropertyGroup><SomeProperty>8.0</SomeProperty></PropertyGroup></Project>", ProcessingResult.None)]
     [InlineData("<Project><PropertyGroup><SomeProperty>SomeValue</SomeProperty></PropertyGroup></Project>", ProcessingResult.None)]
+    [InlineData("<Project><PropertyGroup><SomeProperty>net462</SomeProperty></PropertyGroup></Project>", ProcessingResult.None)]
     public async Task UpgradeAsync_Handles_Invalid_Xml(string content, ProcessingResult expected)
     {
         // Arrange


### PR DESCRIPTION
- Allow updating target frameworks when multi-targeting with frameworks that include `netstandardx.x` or `net4x`.
- If a line contains the expected TFM in it after upgrade, do not warn about it containing leftover references.
