### PR TITLE
Add custom configuration file

### DIFF
--- a/DotNetBumper.sln
+++ b/DotNetBumper.sln
@@ -24,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
+		dotnet-bumper-schema.json = dotnet-bumper-schema.json
 		DotNetBumper.ruleset = DotNetBumper.ruleset
 		DotNetBumper.snk = DotNetBumper.snk
 		exclusion.dic = exclusion.dic

--- a/dotnet-bumper-schema.json
+++ b/dotnet-bumper-schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "https://github.com/martincostello/dotnet-bumper/blob/main/dotnet-bumper-schema.json",
+  "title": "JSON Schema for configuring .NET Bumper",
+  "type": "object",
+  "properties": {
+    "excludeNuGetPackages": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Any NuGet packages to exclude from updating."
+    },
+    "includeNuGetPackages": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Any NuGet packages to include when updating."
+    },
+    "noWarn": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Any MSBuild warnings to ignore."
+    },
+    "remainingReferencesIgnore": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "The project-relative path(s) to ignore from searching for remaining references."
+    }
+  }
+}

--- a/src/DotNetBumper.Core/BumperConfiguration.cs
+++ b/src/DotNetBumper.Core/BumperConfiguration.cs
@@ -23,14 +23,14 @@ internal sealed class BumperConfiguration
     public HashSet<string> IncludeNuGetPackages { get; set; } = [];
 
     /// <summary>
-    /// Gets or sets the path(s) to ignore from searching for remaining references.
-    /// </summary>
-    [JsonPropertyName("remainingReferencesIgnore")]
-    public HashSet<string> RemainingReferencesIgnore { get; set; } = [];
-
-    /// <summary>
     /// Gets or sets any MSBuild warnings to ignore.
     /// </summary>
     [JsonPropertyName("noWarn")]
     public HashSet<string> NoWarn { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the path(s) to ignore from searching for remaining references.
+    /// </summary>
+    [JsonPropertyName("remainingReferencesIgnore")]
+    public HashSet<string> RemainingReferencesIgnore { get; set; } = [];
 }

--- a/src/DotNetBumper.Core/BumperConfiguration.cs
+++ b/src/DotNetBumper.Core/BumperConfiguration.cs
@@ -29,7 +29,7 @@ internal sealed class BumperConfiguration
     public HashSet<string> NoWarn { get; set; } = [];
 
     /// <summary>
-    /// Gets or sets the path(s) to ignore from searching for remaining references.
+    /// Gets or sets the project-path(s) to ignore from searching for remaining references.
     /// </summary>
     [JsonPropertyName("remainingReferencesIgnore")]
     public HashSet<string> RemainingReferencesIgnore { get; set; } = [];

--- a/src/DotNetBumper.Core/BumperConfiguration.cs
+++ b/src/DotNetBumper.Core/BumperConfiguration.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.DotNetBumper;
+
+/// <summary>
+/// A class representing the custom configuration for .NET Bumper. This class cannot be inherited.
+/// </summary>
+internal sealed class BumperConfiguration
+{
+    /// <summary>
+    /// Gets or sets the NuGet packages to exclude from updating.
+    /// </summary>
+    [JsonPropertyName("excludeNuGetPackages")]
+    public HashSet<string> ExcludeNuGetPackages { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the NuGet packages to include when updating.
+    /// </summary>
+    [JsonPropertyName("includeNuGetPackages")]
+    public HashSet<string> IncludeNuGetPackages { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the path(s) to ignore from searching for remaining references.
+    /// </summary>
+    [JsonPropertyName("remainingReferencesIgnore")]
+    public HashSet<string> RemainingReferencesIgnore { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets any MSBuild warnings to ignore.
+    /// </summary>
+    [JsonPropertyName("noWarn")]
+    public HashSet<string> NoWarn { get; set; } = [];
+}

--- a/src/DotNetBumper.Core/BumperConfigurationLoader.cs
+++ b/src/DotNetBumper.Core/BumperConfigurationLoader.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace MartinCostello.DotNetBumper;
+
+internal partial class BumperConfigurationLoader(
+    IOptions<UpgradeOptions> options,
+    ILogger<BumperConfigurationLoader> logger)
+{
+    public virtual async Task<BumperConfiguration?> LoadAsync(CancellationToken cancellationToken)
+    {
+        (var fileName, bool isJson) = FindConfiguration();
+
+        BumperConfiguration? configuration = null;
+
+        if (fileName is not null)
+        {
+            configuration = isJson ? await DeserializeJsonAsync(fileName, cancellationToken) : DeserializeYaml(fileName);
+        }
+
+        return configuration ?? new();
+    }
+
+    private (string? Path, bool IsJson) FindConfiguration()
+    {
+        var path = options.Value.ProjectPath;
+
+        var fileNames = new[]
+        {
+            (Path.Combine(path, ".dotnet-bumper.json"), true),
+            (Path.Combine(path, ".dotnet-bumper.yml"), false),
+            (Path.Combine(path, ".dotnet-bumper.yaml"), false),
+        };
+
+        foreach ((var fileName, bool isJson) in fileNames)
+        {
+            if (File.Exists(fileName))
+            {
+                return (fileName, isJson);
+            }
+        }
+
+        return (null, true);
+    }
+
+    private async Task<BumperConfiguration?> DeserializeJsonAsync(string fileName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var stream = File.OpenRead(fileName);
+            return await JsonSerializer.DeserializeAsync(stream, BumperJsonSerializerContext.Default.BumperConfiguration, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Log.FailedToLoadJson(logger, fileName, ex);
+            return null;
+        }
+    }
+
+    private BumperConfiguration? DeserializeYaml(string fileName)
+    {
+        var deserializer = new DeserializerBuilder()
+            .IgnoreUnmatchedProperties()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build();
+
+        using var stream = File.OpenRead(fileName);
+        using var reader = new StreamReader(stream);
+
+        try
+        {
+            return deserializer.Deserialize<BumperConfiguration>(reader);
+        }
+        catch (Exception ex)
+        {
+            Log.FailedToLoadYaml(logger, fileName, ex);
+            return null;
+        }
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 1,
+            Level = LogLevel.Warning,
+            Message = "Failed to load JSON configuration file {FileName}.")]
+        public static partial void FailedToLoadJson(ILogger logger, string fileName, Exception exception);
+
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Warning,
+            Message = "Failed to load YAML configuration file {FileName}.")]
+        public static partial void FailedToLoadYaml(ILogger logger, string fileName, Exception exception);
+    }
+}

--- a/src/DotNetBumper.Core/BumperConfigurationLoader.cs
+++ b/src/DotNetBumper.Core/BumperConfigurationLoader.cs
@@ -24,7 +24,7 @@ internal partial class BumperConfigurationLoader(
             configuration = isJson ? await DeserializeJsonAsync(fileName, cancellationToken) : DeserializeYaml(fileName);
         }
 
-        return configuration ?? new();
+        return configuration;
     }
 
     private (string? Path, bool IsJson) FindConfiguration()

--- a/src/DotNetBumper.Core/BumperConfigurationLoader.cs
+++ b/src/DotNetBumper.Core/BumperConfigurationLoader.cs
@@ -41,7 +41,7 @@ internal partial class BumperConfigurationLoader(
                 throw new FileNotFoundException("The specified custom configuration file could not be found.", userConfig);
             }
 
-            bool isJson = string.Equals(Path.GetExtension(userConfig) ?? "json", "json", StringComparison.Ordinal);
+            bool isJson = string.Equals(Path.GetExtension(userConfig) ?? "json", "json", StringComparison.OrdinalIgnoreCase);
             return (userConfig, isJson, true);
         }
 

--- a/src/DotNetBumper.Core/BumperConfigurationProvider.cs
+++ b/src/DotNetBumper.Core/BumperConfigurationProvider.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace MartinCostello.DotNetBumper;
+
+internal sealed partial class BumperConfigurationProvider(
+    BumperConfigurationLoader loader,
+    IOptions<UpgradeOptions> options,
+    ILogger<BumperConfigurationProvider> logger)
+{
+    private BumperConfiguration? _configuration;
+
+    public async Task<BumperConfiguration> GetAsync(CancellationToken cancellationToken)
+    {
+        return _configuration ??= await InitializeAsync(cancellationToken);
+    }
+
+    private async Task<BumperConfiguration> InitializeAsync(CancellationToken cancellationToken)
+    {
+        var configuration = new BumperConfiguration()
+        {
+            IncludeNuGetPackages =
+            {
+                "Microsoft.AspNetCore.",
+                "Microsoft.EntityFrameworkCore.",
+                "Microsoft.Extensions.",
+                "System.Text.Json",
+            },
+        };
+
+        if (options.Value.UpgradeType is not UpgradeType.Preview)
+        {
+            configuration.IncludeNuGetPackages.Add("Microsoft.NET.Test.Sdk");
+        }
+
+        // HACK See https://github.com/dotnet-outdated/dotnet-outdated/pull/516
+        configuration.NoWarn.Add("NU1605");
+
+        if (await loader.LoadAsync(cancellationToken) is { } custom)
+        {
+            configuration.IncludeNuGetPackages.UnionWith(custom.IncludeNuGetPackages);
+            configuration.ExcludeNuGetPackages.UnionWith(custom.ExcludeNuGetPackages);
+            configuration.NoWarn.UnionWith(custom.NoWarn);
+            configuration.RemainingReferencesIgnore.UnionWith(custom.RemainingReferencesIgnore);
+        }
+
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            Log.IncludedNuGetPackages(logger, [..configuration.IncludeNuGetPackages]);
+            Log.ExcludedNuGetPackages(logger, [..configuration.ExcludeNuGetPackages]);
+            Log.NoWarn(logger, [..configuration.NoWarn]);
+            Log.IgnoreRemainingReferences(logger, [..configuration.RemainingReferencesIgnore]);
+        }
+
+        return configuration;
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 1,
+            Level = LogLevel.Debug,
+            Message = "Included update NuGet packages: {Packages}",
+            SkipEnabledCheck = true)]
+        public static partial void IncludedNuGetPackages(ILogger logger, string[] packages);
+
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Debug,
+            Message = "Excluded update NuGet packages: {Packages}",
+            SkipEnabledCheck = true)]
+        public static partial void ExcludedNuGetPackages(ILogger logger, string[] packages);
+
+        [LoggerMessage(
+            EventId = 3,
+            Level = LogLevel.Debug,
+            Message = "Ignored MSBuild warnings: {NoWarn}",
+            SkipEnabledCheck = true)]
+        public static partial void NoWarn(ILogger logger, string[] noWarn);
+
+        [LoggerMessage(
+            EventId = 4,
+            Level = LogLevel.Debug,
+            Message = "Ignored remaining references: {References}",
+            SkipEnabledCheck = true)]
+        public static partial void IgnoreRemainingReferences(ILogger logger, string[] references);
+    }
+}

--- a/src/DotNetBumper.Core/BumperJsonSerializerContext.cs
+++ b/src/DotNetBumper.Core/BumperJsonSerializerContext.cs
@@ -2,11 +2,15 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace MartinCostello.DotNetBumper;
 
 [ExcludeFromCodeCoverage]
 [JsonSerializable(typeof(BumperConfiguration))]
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSourceGenerationOptions(
+    AllowTrailingCommas = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    ReadCommentHandling = JsonCommentHandling.Skip)]
 internal sealed partial class BumperJsonSerializerContext : JsonSerializerContext;

--- a/src/DotNetBumper.Core/BumperJsonSerializerContext.cs
+++ b/src/DotNetBumper.Core/BumperJsonSerializerContext.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.DotNetBumper;
+
+[ExcludeFromCodeCoverage]
+[JsonSerializable(typeof(BumperConfiguration))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal sealed partial class BumperJsonSerializerContext : JsonSerializerContext;

--- a/src/DotNetBumper.Core/DotNetBumper.Core.csproj
+++ b/src/DotNetBumper.Core/DotNetBumper.Core.csproj
@@ -29,5 +29,6 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="DotNetBumper.Tests" Key="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 </Project>

--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -43,6 +43,8 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton(configuration)
                 .AddSingleton<DotNetProcess>()
+                .AddSingleton<BumperConfigurationLoader>()
+                .AddSingleton<BumperConfigurationProvider>()
                 .AddSingleton<BumperLogContext>()
                 .AddSingleton<IAnsiConsole>(console)
                 .AddSingleton<IEnvironment, BumperEnvironment>()

--- a/src/DotNetBumper.Core/UpgradeOptions.cs
+++ b/src/DotNetBumper.Core/UpgradeOptions.cs
@@ -11,6 +11,11 @@ namespace MartinCostello.DotNetBumper;
 public sealed class UpgradeOptions
 {
     /// <summary>
+    /// Gets or sets the path of a custom JSON or YAML configuration file, if any.
+    /// </summary>
+    public string? ConfigurationPath { get; set; }
+
+    /// <summary>
     /// Gets or sets a specific .NET release channel to upgrade to.
     /// </summary>
     public string? DotNetChannel { get; set; }

--- a/src/DotNetBumper.Core/UpgradeOptionsValidator.cs
+++ b/src/DotNetBumper.Core/UpgradeOptionsValidator.cs
@@ -9,6 +9,12 @@ internal sealed class UpgradeOptionsValidator : IValidateOptions<UpgradeOptions>
 {
     public ValidateOptionsResult Validate(string? name, UpgradeOptions options)
     {
+        if (options.ConfigurationPath is { Length: > 0 } &&
+            !File.Exists(options.ConfigurationPath))
+        {
+            return ValidateOptionsResult.Fail($"The specified configuration file \"{options.ConfigurationPath}\" cannot be found.");
+        }
+
         if (options.DotNetChannel is { Length: > 0 } version &&
             !Version.TryParse(version, out _))
         {

--- a/src/DotNetBumper/Bumper.cs
+++ b/src/DotNetBumper/Bumper.cs
@@ -23,6 +23,11 @@ internal partial class Bumper(ProjectUpgrader upgrader)
     public string? ProjectPath { get; set; }
 
     [Option(
+        "-cf|--configuration-file <PATH>",
+        Description = "The path to a custom JSON or YAML configuration file to use, if any.")]
+    public string? ConfigurationFile { get; set; }
+
+    [Option(
         "-c|--channel <CHANNEL>",
         Description = "The .NET release channel to upgrade to in the format \"major.minor\".")]
     public string? DotNetChannel { get; set; }

--- a/src/DotNetBumper/UpgradePostConfigureOptions.cs
+++ b/src/DotNetBumper/UpgradePostConfigureOptions.cs
@@ -17,6 +17,11 @@ internal sealed class UpgradePostConfigureOptions(IModelAccessor accessor) : IPo
         options.TestUpgrade = command.TestUpgrade;
         options.TreatWarningsAsErrors = command.WarningsAsErrors;
 
+        if (command.ConfigurationFile is not null)
+        {
+            options.ConfigurationPath = Path.GetFullPath(command.ConfigurationFile);
+        }
+
         if (!string.IsNullOrWhiteSpace(command.ProjectPath))
         {
             options.ProjectPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(command.ProjectPath));

--- a/tests/DotNetBumper.Tests/BumperConfigurationLoaderTests.cs
+++ b/tests/DotNetBumper.Tests/BumperConfigurationLoaderTests.cs
@@ -160,7 +160,7 @@ public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData(".dotnet-bumper.json", "Not JSON")]
+    [InlineData(".dotnet-bumper.json", "<NotJson/>")]
     [InlineData(".dotnet-bumper.yml", "Not YAML")]
     public async Task LoadAsync_Handles_Invalid_Content(string fileName, string content)
     {

--- a/tests/DotNetBumper.Tests/BumperConfigurationLoaderTests.cs
+++ b/tests/DotNetBumper.Tests/BumperConfigurationLoaderTests.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper;
+
+public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task LoadAsync_When_No_Custom_Configuration()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.LoadAsync(CancellationToken.None);
+
+        // Assert
+        actual.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task LoadAsync_When_Json_Configuration()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+        await CreateJsonConfigurationAsync(fixture);
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.LoadAsync(CancellationToken.None);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ExcludeNuGetPackages.ShouldBe(["exclude-json-1", "exclude-json-2"]);
+        actual.IncludeNuGetPackages.ShouldBe(["include-json-1", "include-json-2"]);
+        actual.NoWarn.ShouldBe(["no-warn-json-1", "no-warn-json-2"]);
+        actual.RemainingReferencesIgnore.ShouldBe(["ignore-json-1", "ignore-json-2"]);
+    }
+
+    [Theory]
+    [InlineData("yml")]
+    [InlineData("yaml")]
+    public async Task LoadAsync_When_Yaml_Configuration(string extension)
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+        await CreateYamlConfigurationAsync(fixture, extension);
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.LoadAsync(CancellationToken.None);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ExcludeNuGetPackages.ShouldBe(["exclude-yaml-1", "exclude-yaml-2"]);
+        actual.IncludeNuGetPackages.ShouldBe(["include-yaml-1", "include-yaml-2"]);
+        actual.NoWarn.ShouldBe(["no-warn-yaml-1", "no-warn-yaml-2"]);
+        actual.RemainingReferencesIgnore.ShouldBe(["ignore-yaml-1", "ignore-yaml-2"]);
+    }
+
+    [Fact]
+    public async Task LoadAsync_When_Json_And_Yaml_Configuration()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        await CreateJsonConfigurationAsync(fixture);
+        await CreateYamlConfigurationAsync(fixture);
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.LoadAsync(CancellationToken.None);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ExcludeNuGetPackages.ShouldBe(["exclude-json-1", "exclude-json-2"]);
+        actual.IncludeNuGetPackages.ShouldBe(["include-json-1", "include-json-2"]);
+        actual.NoWarn.ShouldBe(["no-warn-json-1", "no-warn-json-2"]);
+        actual.RemainingReferencesIgnore.ShouldBe(["ignore-json-1", "ignore-json-2"]);
+    }
+
+    [Theory]
+    [InlineData(".dotnet-bumper.json", "Not JSON")]
+    [InlineData(".dotnet-bumper.yml", "Not YAML")]
+    public async Task LoadAsync_Handles_Invalid_Content(string fileName, string content)
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        await File.WriteAllTextAsync(Path.Combine(fixture.Project.DirectoryName, fileName), content);
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.LoadAsync(CancellationToken.None);
+
+        // Assert
+        actual.ShouldBeNull();
+    }
+
+    internal static async Task CreateJsonConfigurationAsync(UpgraderFixture fixture)
+    {
+        var path = Path.Combine(fixture.Project.DirectoryName, ".dotnet-bumper.json");
+
+        string content =
+            """
+            {
+              /* Custom JSON configuration */
+              "excludeNuGetPackages": [
+                "exclude-json-1",
+                "exclude-json-2",
+              ],
+              "includeNuGetPackages": [
+                "include-json-1",
+                "include-json-2",
+              ],
+              "noWarn": [
+                "no-warn-json-1",
+                "no-warn-json-2",
+              ],
+              "remainingReferencesIgnore": [
+                "ignore-json-1",
+                "ignore-json-2",
+              ],
+            }
+            """;
+
+        await File.WriteAllTextAsync(path, content);
+    }
+
+    internal static async Task CreateYamlConfigurationAsync(UpgraderFixture fixture, string extension = "yml")
+    {
+        var path = Path.Combine(fixture.Project.DirectoryName, $".dotnet-bumper.{extension}");
+
+        string content =
+            """
+            # Custom YAML configuration
+            excludeNuGetPackages:
+              - exclude-yaml-1
+              - exclude-yaml-2
+            includeNuGetPackages:
+              - include-yaml-1
+              - include-yaml-2
+            noWarn:
+              - no-warn-yaml-1
+              - no-warn-yaml-2
+            remainingReferencesIgnore:
+              - ignore-yaml-1
+              - ignore-yaml-2
+            """;
+
+        await File.WriteAllTextAsync(path, content);
+    }
+
+    private static BumperConfigurationLoader CreateTarget(UpgraderFixture fixture)
+    {
+        return new(fixture.CreateOptions(), fixture.CreateLogger<BumperConfigurationLoader>());
+    }
+}

--- a/tests/DotNetBumper.Tests/BumperConfigurationProviderTests.cs
+++ b/tests/DotNetBumper.Tests/BumperConfigurationProviderTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper;
+
+public class BumperConfigurationProviderTests(ITestOutputHelper outputHelper)
+{
+    [Theory]
+    [InlineData(UpgradeType.Latest)]
+    [InlineData(UpgradeType.Lts)]
+    public async Task GetAsync_When_No_Custom_Configuration_For_Stable(UpgradeType upgradeType)
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        var target = CreateTarget(fixture, upgradeType);
+
+        // Act
+        var actual = await target.GetAsync(CancellationToken.None);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ExcludeNuGetPackages.ShouldBe([]);
+        actual.IncludeNuGetPackages.ShouldBe(["Microsoft.AspNetCore.", "Microsoft.EntityFrameworkCore.", "Microsoft.Extensions.", "System.Text.Json", "Microsoft.NET.Test.Sdk"]);
+        actual.NoWarn.ShouldBe(["NU1605"]);
+        actual.RemainingReferencesIgnore.ShouldBe([]);
+    }
+
+    [Fact]
+    public async Task GetAsync_When_No_Custom_Configuration_For_Preview()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        var target = CreateTarget(fixture, UpgradeType.Preview);
+
+        // Act
+        var actual = await target.GetAsync(CancellationToken.None);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ExcludeNuGetPackages.ShouldBe([]);
+        actual.IncludeNuGetPackages.ShouldBe(["Microsoft.AspNetCore.", "Microsoft.EntityFrameworkCore.", "Microsoft.Extensions.", "System.Text.Json"]);
+        actual.NoWarn.ShouldBe(["NU1605"]);
+        actual.RemainingReferencesIgnore.ShouldBe([]);
+    }
+
+    [Fact]
+    public async Task GetAsync_When_Json_Configuration()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+        await BumperConfigurationLoaderTests.CreateJsonConfigurationAsync(fixture);
+
+        var target = CreateTarget(fixture, UpgradeType.Preview);
+
+        // Act
+        var actual = await target.GetAsync(CancellationToken.None);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ExcludeNuGetPackages.ShouldBe(["exclude-json-1", "exclude-json-2"]);
+        actual.IncludeNuGetPackages.ShouldBe(["Microsoft.AspNetCore.", "Microsoft.EntityFrameworkCore.", "Microsoft.Extensions.", "System.Text.Json", "include-json-1", "include-json-2"]);
+        actual.NoWarn.ShouldBe(["NU1605", "no-warn-json-1", "no-warn-json-2"]);
+        actual.RemainingReferencesIgnore.ShouldBe(["ignore-json-1", "ignore-json-2"]);
+    }
+
+    [Fact]
+    public async Task GetAsync_When_Yaml_Configuration()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+        await BumperConfigurationLoaderTests.CreateYamlConfigurationAsync(fixture);
+
+        var target = CreateTarget(fixture, UpgradeType.Preview);
+
+        // Act
+        var actual = await target.GetAsync(CancellationToken.None);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ExcludeNuGetPackages.ShouldBe(["exclude-yaml-1", "exclude-yaml-2"]);
+        actual.IncludeNuGetPackages.ShouldBe(["Microsoft.AspNetCore.", "Microsoft.EntityFrameworkCore.", "Microsoft.Extensions.", "System.Text.Json", "include-yaml-1", "include-yaml-2"]);
+        actual.NoWarn.ShouldBe(["NU1605", "no-warn-yaml-1", "no-warn-yaml-2"]);
+        actual.RemainingReferencesIgnore.ShouldBe(["ignore-yaml-1", "ignore-yaml-2"]);
+    }
+
+    private static BumperConfigurationProvider CreateTarget(UpgraderFixture fixture, UpgradeType? upgradeType = null)
+    {
+        var options = fixture.CreateOptions();
+
+        if (upgradeType is { } value)
+        {
+            options.Value.UpgradeType = value;
+        }
+
+        var loader = new BumperConfigurationLoader(options, fixture.CreateLogger<BumperConfigurationLoader>());
+
+        return new(loader, options, fixture.CreateLogger<BumperConfigurationProvider>());
+    }
+}

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -438,6 +438,23 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task Application_Validates_Configuration_File_Exists()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        // Act
+        int actual = await Bumper.RunAsync(
+            fixture.Console,
+            [fixture.Project.DirectoryName, "--configuration-file", "foo.txt"],
+            (builder) => builder.AddXUnit(outputHelper),
+            CancellationToken.None);
+
+        // Assert
+        actual.ShouldBe(1);
+    }
+
+    [Fact]
     public async Task Application_Handles_Unknown_Options()
     {
         // Arrange

--- a/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
@@ -75,6 +75,11 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
     {
         // Arrange
         using var fixture = new UpgraderFixture(outputHelper);
+
+        fixture.UserConfiguration.RemainingReferencesIgnore.Add("tests\\fixtures\\*");
+
+        await fixture.Project.AddFileAsync("tests/fixtures/testdata.txt", "net6.0");
+
         var target = CreateTarget(fixture);
 
         // Act

--- a/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
@@ -194,9 +194,24 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
         var environment = Substitute.For<IEnvironment>();
         environment.SupportsLinks.Returns(true);
 
+        var options = fixture.CreateOptions();
+
+        var configurationLoader = Substitute.For<BumperConfigurationLoader>(
+            options,
+            fixture.CreateLogger<BumperConfigurationLoader>());
+
+        configurationLoader.LoadAsync(Arg.Any<CancellationToken>())
+                           .Returns(fixture.UserConfiguration);
+
+        var configurationProvider = new BumperConfigurationProvider(
+            configurationLoader,
+            options,
+            fixture.CreateLogger<BumperConfigurationProvider>());
+
         return new(
             fixture.Console,
             environment,
+            configurationProvider,
             fixture.LogContext,
             fixture.CreateOptions(),
             fixture.CreateLogger<LeftoverReferencesPostProcessor>());

--- a/tests/DotNetBumper.Tests/UpgraderFixture.cs
+++ b/tests/DotNetBumper.Tests/UpgraderFixture.cs
@@ -32,6 +32,8 @@ internal sealed class UpgraderFixture(
         set => throw new NotSupportedException();
     }
 
+    public BumperConfiguration UserConfiguration { get; } = new();
+
     public ILogger<T> CreateLogger<T>()
         => outputHelper.ToLogger<T>();
 


### PR DESCRIPTION
Allow some options to be overridden by a user-specified configuration file.

The file is read from one of the following locations in order of precedence:

- `--configuration-file <PATH>`
- `.dotnet-bumper.json` in the specified project location
- `.dotnet-bumper.yml` in the specified project location
- `.dotnet-bumper.yaml` in the specified project location

The configuration settings are merged with the in-memory defaults.

Resolves #84.
