### PR TITLE
Suppress preview-specific warnings

### DIFF
--- a/src/DotNetBumper.Core/BumperConfigurationProvider.cs
+++ b/src/DotNetBumper.Core/BumperConfigurationProvider.cs
@@ -31,7 +31,12 @@ internal sealed partial class BumperConfigurationProvider(
             },
         };
 
-        if (options.Value.UpgradeType is not UpgradeType.Preview)
+        if (options.Value.UpgradeType is UpgradeType.Preview)
+        {
+            configuration.NoWarn.Add("NETSDK1057");
+            configuration.NoWarn.Add("NU5104");
+        }
+        else
         {
             configuration.IncludeNuGetPackages.Add("Microsoft.NET.Test.Sdk");
         }

--- a/tests/DotNetBumper.Tests/BumperConfigurationProviderTests.cs
+++ b/tests/DotNetBumper.Tests/BumperConfigurationProviderTests.cs
@@ -41,7 +41,7 @@ public class BumperConfigurationProviderTests(ITestOutputHelper outputHelper)
         actual.ShouldNotBeNull();
         actual.ExcludeNuGetPackages.ShouldBe([]);
         actual.IncludeNuGetPackages.ShouldBe(["Microsoft.AspNetCore.", "Microsoft.EntityFrameworkCore.", "Microsoft.Extensions.", "System.Text.Json"]);
-        actual.NoWarn.ShouldBe(["NU1605"]);
+        actual.NoWarn.ShouldBe(["NETSDK1057", "NU5104", "NU1605"]);
         actual.RemainingReferencesIgnore.ShouldBe([]);
     }
 
@@ -61,7 +61,7 @@ public class BumperConfigurationProviderTests(ITestOutputHelper outputHelper)
         actual.ShouldNotBeNull();
         actual.ExcludeNuGetPackages.ShouldBe(["exclude-json-1", "exclude-json-2"]);
         actual.IncludeNuGetPackages.ShouldBe(["Microsoft.AspNetCore.", "Microsoft.EntityFrameworkCore.", "Microsoft.Extensions.", "System.Text.Json", "include-json-1", "include-json-2"]);
-        actual.NoWarn.ShouldBe(["NU1605", "no-warn-json-1", "no-warn-json-2"]);
+        actual.NoWarn.ShouldBe(["NETSDK1057", "NU5104", "NU1605", "no-warn-json-1", "no-warn-json-2"]);
         actual.RemainingReferencesIgnore.ShouldBe(["ignore-json-1", "ignore-json-2"]);
     }
 
@@ -81,7 +81,7 @@ public class BumperConfigurationProviderTests(ITestOutputHelper outputHelper)
         actual.ShouldNotBeNull();
         actual.ExcludeNuGetPackages.ShouldBe(["exclude-yaml-1", "exclude-yaml-2"]);
         actual.IncludeNuGetPackages.ShouldBe(["Microsoft.AspNetCore.", "Microsoft.EntityFrameworkCore.", "Microsoft.Extensions.", "System.Text.Json", "include-yaml-1", "include-yaml-2"]);
-        actual.NoWarn.ShouldBe(["NU1605", "no-warn-yaml-1", "no-warn-yaml-2"]);
+        actual.NoWarn.ShouldBe(["NETSDK1057", "NU5104", "NU1605", "no-warn-yaml-1", "no-warn-yaml-2"]);
         actual.RemainingReferencesIgnore.ShouldBe(["ignore-yaml-1", "ignore-yaml-2"]);
     }
 


### PR DESCRIPTION
- Suppress `NETSDK1057` warnings about a preview .NET SDK.
- Suppress `NU5104` warnings about depending on pre-release package versions.
