### PR TITLE
Handle custom Dockerfile names

### DIFF
--- a/src/DotNetBumper.Core/Upgraders/DockerfileUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DockerfileUpgrader.cs
@@ -24,7 +24,7 @@ internal sealed partial class DockerfileUpgrader(
 
     protected override string InitialStatus => "Update Dockerfiles";
 
-    protected override IReadOnlyList<string> Patterns => ["Dockerfile"];
+    protected override IReadOnlyList<string> Patterns => ["*Dockerfile"];
 
     internal static Match DockerImageMatch(string value) => DockerImage().Match(value);
 

--- a/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
@@ -268,7 +268,7 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
         // Arrange
         using var fixture = new UpgraderFixture(outputHelper);
 
-        string vsconfig = await fixture.Project.AddFileAsync("aws-lambda-tools-defaults.json", content);
+        string vsconfig = await fixture.Project.AddFileAsync("Dockerfile", content);
 
         var upgrade = new UpgradeInfo()
         {
@@ -438,7 +438,7 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
 
         using var fixture = new UpgraderFixture(outputHelper);
 
-        string dockerfile = await fixture.Project.AddFileAsync("Dockerfile", fileContents);
+        string dockerfile = await fixture.Project.AddFileAsync("Custom.Dockerfile", fileContents);
 
         var upgrade = new UpgradeInfo()
         {


### PR DESCRIPTION
Upgrade any file name that ends with `Dockerfile`, rather than _exactly_ the name `Dockerfile`.

From the [Docker documentation](https://docs.docker.com/build/building/packaging/#filename):

> Some projects may need distinct Dockerfiles for specific purposes. A common convention is to name these <something>.Dockerfile. You can specify the Dockerfile filename using the --file flag for the docker build command.
