### PR TITLE
Update target framework in pubxml files

### DIFF
--- a/src/DotNetBumper.Core/Upgraders/TargetFrameworkHelpers.cs
+++ b/src/DotNetBumper.Core/Upgraders/TargetFrameworkHelpers.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+internal static class TargetFrameworkHelpers
+{
+    private static readonly char[] PathSeparators = ['\\', '/'];
+
+    public static bool TryUpdateTfm(
+        ReadOnlySpan<char> value,
+        Version channel,
+        [NotNullWhen(true)] out string? updated)
+    {
+        const char Delimiter = ';';
+
+        updated = null;
+        var remaining = value;
+
+        int validTfms = 0;
+        int updateableTfms = 0;
+
+        while (!remaining.IsEmpty)
+        {
+            int index = remaining.IndexOf(Delimiter);
+            var part = index is -1 ? remaining : remaining[..index];
+
+            if (!part.IsEmpty)
+            {
+                if (!part.IsTargetFrameworkMoniker())
+                {
+                    if (!part.StartsWith("net4") &&
+                        !part.StartsWith("netstandard"))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    var version = part.ToVersionFromTargetFramework();
+
+                    if (version is null || version >= channel)
+                    {
+                        return false;
+                    }
+
+                    updateableTfms++;
+                }
+
+                validTfms++;
+            }
+
+            remaining = remaining[(index + 1)..];
+
+            if (index is -1)
+            {
+                break;
+            }
+        }
+
+        if (updateableTfms < 1)
+        {
+            return false;
+        }
+
+        var newTfm = channel.ToTargetFramework();
+        var append = validTfms > 1;
+
+        if (append)
+        {
+            updated = new StringBuilder()
+                .Append(value)
+                .Append(Delimiter)
+                .Append(newTfm)
+                .ToString();
+        }
+        else
+        {
+            updated = newTfm;
+        }
+
+        return !value.SequenceEqual(updated);
+    }
+
+    public static bool TryUpdateTfmInPath(
+        string value,
+        Version channel,
+        [NotNullWhen(true)] out string? updated)
+    {
+        updated = null;
+
+        if (!value.Split(PathSeparators).Any((p) => p.IsTargetFrameworkMoniker()))
+        {
+            return false;
+        }
+
+        var builder = new StringBuilder();
+        var remaining = value.AsSpan();
+
+        bool updateValue = false;
+
+        while (!remaining.IsEmpty)
+        {
+            int index = remaining.IndexOfAny(PathSeparators);
+            var maybeTfm = remaining;
+
+            if (index is not -1)
+            {
+                maybeTfm = maybeTfm[..index];
+            }
+
+            int consumed = maybeTfm.Length;
+
+            if (maybeTfm.IsTargetFrameworkMoniker())
+            {
+                if (maybeTfm.ToVersionFromTargetFramework() is { } version && version < channel)
+                {
+                    maybeTfm = channel.ToTargetFramework();
+                    updateValue = true;
+                }
+            }
+
+            builder.Append(maybeTfm);
+
+            if (index is not -1)
+            {
+                builder.Append(remaining.Slice(index, 1));
+                consumed++;
+            }
+
+            remaining = remaining[consumed..];
+        }
+
+        if (updateValue)
+        {
+            updated = builder.ToString();
+
+            Debug.Assert(updated.Length > 0, "The updated value should have a length.");
+            Debug.Assert(updated != value, "The value is was not updated.");
+        }
+
+        return updateValue;
+    }
+}

--- a/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Xml;
 using System.Xml.Linq;
 using MartinCostello.DotNetBumper.Logging;
@@ -19,73 +17,11 @@ internal sealed partial class TargetFrameworkUpgrader(
     IOptions<UpgradeOptions> options,
     ILogger<TargetFrameworkUpgrader> logger) : FileUpgrader(console, environment, options, logger)
 {
-    private static readonly char[] PathSeparators = ['\\', '/'];
-
     protected override string Action => "Upgrading target frameworks";
 
     protected override string InitialStatus => "Update TFMs";
 
     protected override IReadOnlyList<string> Patterns => ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml"];
-
-    internal static bool TryUpdatePathTfm(
-        string value,
-        Version channel,
-        [NotNullWhen(true)] out string? updated)
-    {
-        updated = null;
-
-        if (!value.Split(PathSeparators).Any((p) => p.IsTargetFrameworkMoniker()))
-        {
-            return false;
-        }
-
-        var builder = new StringBuilder();
-        var remaining = value.AsSpan();
-
-        bool updateValue = false;
-
-        while (!remaining.IsEmpty)
-        {
-            int index = remaining.IndexOfAny(PathSeparators);
-            var maybeTfm = remaining;
-
-            if (index is not -1)
-            {
-                maybeTfm = maybeTfm[..index];
-            }
-
-            int consumed = maybeTfm.Length;
-
-            if (maybeTfm.IsTargetFrameworkMoniker())
-            {
-                if (maybeTfm.ToVersionFromTargetFramework() is { } version && version < channel)
-                {
-                    maybeTfm = channel.ToTargetFramework();
-                    updateValue = true;
-                }
-            }
-
-            builder.Append(maybeTfm);
-
-            if (index is not -1)
-            {
-                builder.Append(remaining.Slice(index, 1));
-                consumed++;
-            }
-
-            remaining = remaining[consumed..];
-        }
-
-        if (updateValue)
-        {
-            updated = builder.ToString();
-
-            Debug.Assert(updated.Length > 0, "The updated value should have a length.");
-            Debug.Assert(updated != value, "The value is was not updated.");
-        }
-
-        return updateValue;
-    }
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,
@@ -115,8 +51,7 @@ internal sealed partial class TargetFrameworkUpgrader(
 
             foreach (var property in project.Root.Elements("PropertyGroup").Elements())
             {
-                if (TryUpgradeTargetFramework(property, upgrade.Channel) ||
-                    TryUpgradeTargetFrameworkInPath(property, upgrade.Channel))
+                if (TryUpgradeTargetFramework(property, upgrade.Channel))
                 {
                     edited = true;
                 }
@@ -155,73 +90,8 @@ internal sealed partial class TargetFrameworkUpgrader(
 
     private static bool TryUpgradeTargetFramework(XElement property, Version channel)
     {
-        const char Delimiter = ';';
-
-        var current = property.Value.AsSpan();
-        var remaining = current;
-
-        int validTfms = 0;
-        int updateableTfms = 0;
-
-        while (!remaining.IsEmpty)
-        {
-            int index = remaining.IndexOf(Delimiter);
-            var part = index is -1 ? remaining : remaining[..index];
-
-            if (!part.IsEmpty)
-            {
-                if (!part.IsTargetFrameworkMoniker())
-                {
-                    if (!part.StartsWith("net4") &&
-                        !part.StartsWith("netstandard"))
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    var version = part.ToVersionFromTargetFramework();
-
-                    if (version is null || version >= channel)
-                    {
-                        return false;
-                    }
-
-                    updateableTfms++;
-                }
-
-                validTfms++;
-            }
-
-            remaining = remaining[(index + 1)..];
-
-            if (index is -1)
-            {
-                break;
-            }
-        }
-
-        if (updateableTfms < 1)
-        {
-            return false;
-        }
-
-        var newTfm = channel.ToTargetFramework();
-        var append = validTfms > 1;
-        var updated = append ? $"{current};{newTfm}" : newTfm;
-
-        if (!current.SequenceEqual(updated))
-        {
-            property.SetValue(updated);
-            return true;
-        }
-
-        return false;
-    }
-
-    private static bool TryUpgradeTargetFrameworkInPath(XElement property, Version channel)
-    {
-        if (TryUpdatePathTfm(property.Value, channel, out var updated))
+        if (TargetFrameworkHelpers.TryUpdateTfm(property.Value, channel, out var updated) ||
+            TargetFrameworkHelpers.TryUpdateTfmInPath(property.Value, channel, out updated))
         {
             property.SetValue(updated);
             return true;

--- a/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
@@ -21,7 +21,7 @@ internal sealed partial class TargetFrameworkUpgrader(
 
     protected override string InitialStatus => "Update TFMs";
 
-    protected override IReadOnlyList<string> Patterns => ["Directory.Build.props", "*.csproj", "*.fsproj"];
+    protected override IReadOnlyList<string> Patterns => ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml"];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/VisualStudioCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/VisualStudioCodeUpgrader.cs
@@ -105,7 +105,7 @@ internal sealed partial class VisualStudioCodeUpgrader(
 
             string value = node.GetValue<string>();
 
-            if (TargetFrameworkUpgrader.TryUpdatePathTfm(value, channel, out var updated))
+            if (TargetFrameworkHelpers.TryUpdateTfmInPath(value, channel, out var updated))
             {
                 node.ReplaceWith(JsonValue.Create(updated));
                 return true;

--- a/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
@@ -9,8 +9,21 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
 {
     public static TheoryData<string, string, bool, string, string, string> TargetFrameworks()
     {
-        string[] channels = ["7.0", "8.0", "9.0", "10.0"];
-        string[] fileNames = ["Directory.Build.props", "src/MyProject.csproj", "src/MyProject.fsproj"];
+        string[] channels =
+        [
+            "7.0",
+            "8.0",
+            "9.0",
+            "10.0",
+        ];
+
+        string[] fileNames =
+        [
+            "Directory.Build.props",
+            "src/MyProject.csproj",
+            "src/MyProject.fsproj",
+            "src/MyProject/Properties/PublishProfiles/profile.pubxml",
+        ];
 
         var testCases = new TheoryData<string, string, bool, string, string, string>();
 

--- a/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
@@ -34,6 +34,8 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
                 foreach (var hasByteOrderMark in new[] { false, true })
                 {
                     testCases.Add(channel, fileName, hasByteOrderMark, "DefaultTargetFramework", "net6.0", $"net{channel}");
+                    testCases.Add(channel, fileName, hasByteOrderMark, "PublishDir", "bin/Release/net6.0/publish/", $"bin/Release/net{channel}/publish/");
+                    testCases.Add(channel, fileName, hasByteOrderMark, "PublishDir", "bin\\Release\\net6.0\\publish\\", $"bin\\Release\\net{channel}\\publish\\");
                     testCases.Add(channel, fileName, hasByteOrderMark, "TargetFramework", "net6.0", $"net{channel}");
                     testCases.Add(channel, fileName, hasByteOrderMark, "TargetFrameworks", "net5.0;net6.0", $"net5.0;net6.0;net{channel}");
                     testCases.Add(channel, fileName, hasByteOrderMark, "TargetFrameworks", "net5.0;;;;net6.0", $"net5.0;;;;net6.0;net{channel}");


### PR DESCRIPTION
- Include `.pubxml` files when upgrading target frameworks.
- Also update MSBuild properties that contain a path containing a segment that is a target framework.

Resolves #103.
