### PR TITLE
Fix shell scripts not being checked for leftovers

### DIFF
--- a/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
@@ -218,7 +218,10 @@ internal sealed partial class LeftoverReferencesPostProcessor(
 
                 foreach (var rule in await File.ReadAllLinesAsync(gitignore, cancellationToken))
                 {
-                    ignore.Add(rule);
+                    if (!string.IsNullOrWhiteSpace(rule) && !rule.StartsWith('#'))
+                    {
+                        ignore.Add(rule);
+                    }
                 }
             }
         }

--- a/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/LeftoverReferencesPostProcessor.cs
@@ -132,7 +132,7 @@ internal sealed partial class LeftoverReferencesPostProcessor(
 
         return segments.Length >= 1 && segments[0] switch
         {
-            "application" or "font" or "image" or "video" => true,
+            "application" or "font" or "image" or "video" => segments[1] is not "x-sh", // Include shell scripts
             _ => false,
         };
     }

--- a/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
@@ -107,6 +107,7 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
         // Arrange
         using var fixture = new UpgraderFixture(outputHelper);
 
+        await fixture.Project.AddFileAsync("build.sh", "dotnet publish --framework \"net6.0\"");
         await fixture.Project.AddFileAsync("file.txt", "Hello, World!");
         await fixture.Project.AddFileAsync("src/Program.cs", "Console.WriteLine(\"Hello, World!\"");
         await fixture.Project.AddFileAsync("src/Project.csproj", "<Project/>");
@@ -119,8 +120,9 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
         // Assert
         actual.ShouldNotBeNull();
         actual.ShouldNotBeEmpty();
-        actual.Count.ShouldBe(3);
+        actual.Count.ShouldBe(4);
 
+        actual.ShouldContain((p) => p.RelativePath == "build.sh");
         actual.ShouldContain((p) => p.RelativePath == "file.txt");
         actual.ShouldContain((p) => p.RelativePath == "src/Program.cs");
         actual.ShouldContain((p) => p.RelativePath == "src/Project.csproj");


### PR DESCRIPTION
- Fix shell scripts being treated as binary files and not searched for leftover references.
- Ignore empty lines and comments in `.gitignore`.
