### PR TITLE
Apply code analyzer code fixes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -105,6 +105,11 @@ jobs:
       with:
         node-version: '20'
 
+    - name: Checkout ${{ github.repository_owner }}/${{ matrix.repo }}
+      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      with:
+        repository: "${{ github.repository_owner }}/${{ matrix.repo }}"
+
     - name: Install .NET SDKs
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:
@@ -114,6 +119,9 @@ jobs:
           8.0.x
           9.0.x
 
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+
     - name: Install .NET Bumper
       shell: pwsh
       env:
@@ -122,15 +130,7 @@ jobs:
         dotnet tool install --global dotnet-outdated-tool --version ${env:DOTNET_OUTDATED_VERSION}
         dotnet tool install --global MartinCostello.DotNetBumper --add-source ./packages --prerelease
 
-    - name: Checkout ${{ github.repository_owner }}/${{ matrix.repo }}
-      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      with:
-        repository: "${{ github.repository_owner }}/${{ matrix.repo }}"
-
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
-
-    - name: Create .NET Bumper config file if no custom config
+    - name: Generate .NET Bumper config
       id: generate-config
       shell: pwsh
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -177,7 +177,7 @@ jobs:
     - name: Run tests
       shell: pwsh
       run: |
-        dotnet test
+        dotnet test --logger "GitHubActions;report-warnings=false"
 
   integration-tests:
     needs: [ package, test ]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -163,6 +163,12 @@ jobs:
         }
         dotnet bumper $bumperArgs
 
+    - name: Show git diff
+      shell: pwsh
+      run: |
+        git config color.diff always
+        git --no-pager diff
+
   integration-tests:
     needs: [ package, test ]
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -174,6 +174,11 @@ jobs:
         git config color.diff always
         git --no-pager diff
 
+    - name: Run tests
+      shell: pwsh
+      run: |
+        dotnet test
+
   integration-tests:
     needs: [ package, test ]
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         repo:
-          - adventofcode
+          # - adventofcode HACK Disabled due to https://github.com/dotnet/sdk/issues/39909
           - alexa-london-travel
           - alexa-london-travel-site
           - costellobot

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -174,11 +174,6 @@ jobs:
         git config color.diff always
         git --no-pager diff
 
-    - name: Run tests
-      shell: pwsh
-      run: |
-        dotnet test --logger "GitHubActions;report-warnings=false"
-
   integration-tests:
     needs: [ package, test ]
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -100,6 +100,21 @@ jobs:
         name: packages
         path: ./packages
 
+    - name: Setup arm64 support for native AoT
+      if: runner.os == 'Linux' && matrix.repo == 'alexa-london-travel'
+      shell: bash
+      run: |
+        sudo dpkg --add-architecture arm64
+        sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
+        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
+        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
+        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
+        EOF'
+        sudo sed -i -e 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
+        sudo sed -i -e 's/deb mirror/deb [arch=amd64] mirror/g' /etc/apt/sources.list
+        sudo apt update
+        sudo apt install --yes clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
+
     - name: Install .NET SDKs
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -94,12 +94,6 @@ jobs:
 
     steps:
 
-    - name: Download packages
-      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
-      with:
-        name: packages
-        path: ./packages
-
     - name: Setup Node
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
@@ -121,6 +115,12 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+
+    - name: Download packages
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+      with:
+        name: packages
+        path: ./packages
 
     - name: Install .NET Bumper
       shell: pwsh

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -100,20 +100,10 @@ jobs:
         name: packages
         path: ./packages
 
-    - name: Setup arm64 support for native AoT
-      if: runner.os == 'Linux' && matrix.repo == 'alexa-london-travel'
-      shell: bash
-      run: |
-        sudo dpkg --add-architecture arm64
-        sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
-        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
-        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
-        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
-        EOF'
-        sudo sed -i -e 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
-        sudo sed -i -e 's/deb mirror/deb [arch=amd64] mirror/g' /etc/apt/sources.list
-        sudo apt update
-        sudo apt install --yes clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
+    - name: Setup Node
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      with:
+        node-version: '20'
 
     - name: Install .NET SDKs
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,8 +44,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <AssemblyVersion>0.4.0.0</AssemblyVersion>
-    <VersionPrefix>0.4.2</VersionPrefix>
+    <AssemblyVersion>0.5.0.0</AssemblyVersion>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,9 +10,7 @@
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.2.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.9.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,9 @@
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.2.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.9.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />

--- a/DotNetBumper.sln
+++ b/DotNetBumper.sln
@@ -65,6 +65,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\code-scan.yml = .github\workflows\code-scan.yml
 		.github\workflows\dependency-review.yml = .github\workflows\dependency-review.yml
+		.github\workflows\integration-tests.yml = .github\workflows\integration-tests.yml
 		.github\workflows\lint.yml = .github\workflows\lint.yml
 		.github\workflows\ossf-scorecard.yml = .github\workflows\ossf-scorecard.yml
 	EndProjectSection

--- a/src/DotNetBumper.Core/DotNetBumper.Core.csproj
+++ b/src/DotNetBumper.Core/DotNetBumper.Core.csproj
@@ -17,6 +17,8 @@
   <ItemGroup>
     <PackageReference Include="Ignore" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
+    <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/src/DotNetBumper.Core/DotNetBumper.Core.csproj
+++ b/src/DotNetBumper.Core/DotNetBumper.Core.csproj
@@ -17,8 +17,6 @@
   <ItemGroup>
     <PackageReference Include="Ignore" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
-    <PackageReference Include="Microsoft.Build.Locator" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/src/DotNetBumper.Core/LogReader.cs
+++ b/src/DotNetBumper.Core/LogReader.cs
@@ -31,12 +31,44 @@ internal static partial class LogReader
 
                 if (logs.Outcomes.Count > 0)
                 {
-                    result.Outcomes = result.Outcomes.Concat(logs.Outcomes).ToDictionary();
+                    foreach ((var container, var outcomes) in logs.Outcomes)
+                    {
+                        if (!result.Outcomes.TryGetValue(container, out var existing))
+                        {
+                            existing = outcomes;
+                        }
+                        else
+                        {
+                            existing = [.. existing, .. outcomes];
+                        }
+
+                        result.Outcomes[container] = existing;
+                    }
                 }
 
                 if (logs.Summary.Count > 0)
                 {
-                    result.Summary = result.Summary.Concat(logs.Summary).ToDictionary();
+                    foreach ((var container, var summary) in logs.Summary)
+                    {
+                        if (!result.Summary.TryGetValue(container, out var existing))
+                        {
+                            existing = summary;
+                        }
+                        else
+                        {
+                            foreach ((var outcome, var count) in summary)
+                            {
+                                if (!existing.TryGetValue(outcome, out var existingCount))
+                                {
+                                    existingCount = 0;
+                                }
+
+                                existing[outcome] = existingCount + count;
+                            }
+                        }
+
+                        result.Summary[container] = existing;
+                    }
                 }
             }
         }

--- a/src/DotNetBumper.Core/ProjectHelpers.cs
+++ b/src/DotNetBumper.Core/ProjectHelpers.cs
@@ -15,13 +15,13 @@ internal static class ProjectHelpers
     {
         List<string> projects =
         [
-            ..Directory.GetFiles(path, "*.sln", searchOption),
+            .. Directory.GetFiles(path, WellKnownFileNames.SolutionFiles, searchOption),
         ];
 
         if (projects.Count == 0)
         {
-            projects.AddRange(Directory.GetFiles(path, "*.csproj", searchOption));
-            projects.AddRange(Directory.GetFiles(path, "*.fsproj", searchOption));
+            projects.AddRange(Directory.GetFiles(path, WellKnownFileNames.CSharpProjects, searchOption));
+            projects.AddRange(Directory.GetFiles(path, WellKnownFileNames.FSharpProjects, searchOption));
         }
 
         return projects

--- a/src/DotNetBumper.Core/ProjectHelpers.cs
+++ b/src/DotNetBumper.Core/ProjectHelpers.cs
@@ -22,6 +22,7 @@ internal static class ProjectHelpers
         {
             projects.AddRange(Directory.GetFiles(path, WellKnownFileNames.CSharpProjects, searchOption));
             projects.AddRange(Directory.GetFiles(path, WellKnownFileNames.FSharpProjects, searchOption));
+            projects.AddRange(Directory.GetFiles(path, WellKnownFileNames.VisualBasicProjects, searchOption));
         }
 
         return projects

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -67,8 +67,6 @@ public partial class ProjectUpgrader(
             return 0;
         }
 
-        logContext.DotNetSdkVersion = upgrade.SdkVersion.ToString();
-
         var name = Path.GetFileNameWithoutExtension(ProjectPath);
 
         console.MarkupLineInterpolated($"Upgrading project [aqua]{name}[/] to .NET [purple]{upgrade.Channel}[/]...");

--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -70,6 +70,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<IUpgrader, AwsLambdaToolsUpgrader>();
         services.AddSingleton<IUpgrader, DockerfileUpgrader>();
+        services.AddSingleton<IUpgrader, DotNetCodeUpgrader>();
         services.AddSingleton<IUpgrader, GlobalJsonUpgrader>();
         services.AddSingleton<IUpgrader, PackageVersionUpgrader>();
         services.AddSingleton<IUpgrader, PowerShellScriptUpgrader>();

--- a/src/DotNetBumper.Core/Upgraders/AwsLambdaToolsUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/AwsLambdaToolsUpgrader.cs
@@ -20,7 +20,7 @@ internal sealed partial class AwsLambdaToolsUpgrader(
 
     protected override string InitialStatus => "Update AWS Lambda Tools";
 
-    protected override IReadOnlyList<string> Patterns => ["aws-lambda-tools-defaults.json"];
+    protected override IReadOnlyList<string> Patterns { get; } = ["aws-lambda-tools-defaults.json"];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/DockerfileUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DockerfileUpgrader.cs
@@ -22,7 +22,7 @@ internal sealed partial class DockerfileUpgrader(
 
     protected override string InitialStatus => "Update Dockerfiles";
 
-    protected override IReadOnlyList<string> Patterns => ["*Dockerfile"];
+    protected override IReadOnlyList<string> Patterns { get; } = ["*Dockerfile"];
 
     internal static Match DockerImageMatch(string value) => DockerImage().Match(value);
 

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -10,11 +10,11 @@ using Spectre.Console;
 namespace MartinCostello.DotNetBumper.Upgraders;
 
 internal sealed partial class DotNetCodeUpgrader(
+    DotNetProcess dotnet,
     IAnsiConsole console,
     IEnvironment environment,
     BumperLogContext logContext,
     IOptions<UpgradeOptions> options,
-    DotNetProcess dotnet,
     ILogger<DotNetCodeUpgrader> logger) : FileUpgrader(console, environment, options, logger)
 {
     public override int Order => int.MaxValue; // Run after all other upgraders

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -80,7 +80,7 @@ internal sealed partial class DotNetCodeUpgrader(
             "--severity",
             "warn",
             "--verbosity",
-            "normal",
+            "diagnostic",
         ];
 
         // HACK Ignore CA1515 from .NET 9 as it seems to just break things

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -250,17 +250,5 @@ internal sealed partial class DotNetCodeUpgrader(
             Level = LogLevel.Debug,
             Message = "Fixed diagnostic {DiagnosticId} in {FileName}:{LineNumber}.")]
         public static partial void FixedDiagnostic(ILogger logger, string diagnosticId, string fileName, int lineNumber);
-
-        [LoggerMessage(
-            EventId = 4,
-            Level = LogLevel.Debug,
-            Message = "Failed to register MSBuild defaults.")]
-        public static partial void RegisterMSBuildDefaultsFailed(ILogger logger, Exception exception);
-
-        [LoggerMessage(
-            EventId = 5,
-            Level = LogLevel.Debug,
-            Message = "Failed to determine projects included in the solution file {SolutionFile}.")]
-        public static partial void FailedToDetermineSolutionProjects(ILogger logger, string solutionFile, Exception exception);
     }
 }

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -99,6 +99,11 @@ internal sealed partial class DotNetCodeUpgrader(
         Dictionary<string, int> fixes = [];
         ProcessingResult result;
 
+        if (!string.IsNullOrEmpty(formatResult.StandardError))
+        {
+            Log.DotNetFormatErrors(logger, formatResult.StandardError);
+        }
+
         if (formatResult.Success)
         {
             int fixCount = 0;
@@ -195,6 +200,12 @@ internal sealed partial class DotNetCodeUpgrader(
 
         [LoggerMessage(
             EventId = 2,
+            Level = LogLevel.Warning,
+            Message = "dotnet format stderr: {StdErr}")]
+        public static partial void DotNetFormatErrors(ILogger logger, string stderr);
+
+        [LoggerMessage(
+            EventId = 3,
             Level = LogLevel.Debug,
             Message = "Fixed diagnostic {DiagnosticId} in {FileName}:{LineNumber}.")]
         public static partial void FixedDiagnostic(ILogger logger, string diagnosticId, string fileName, int lineNumber);

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -23,7 +23,7 @@ internal sealed partial class DotNetCodeUpgrader(
 
     protected override string InitialStatus => "Update .NET code";
 
-    protected override IReadOnlyList<string> Patterns => ["*.sln", "*.csproj", "*.fsproj", "*.vbproj"];
+    protected override IReadOnlyList<string> Patterns { get; } = ["*.sln", "*.csproj", "*.fsproj", "*.vbproj"];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -14,7 +14,7 @@ internal sealed partial class DotNetCodeUpgrader(
     IEnvironment environment,
     BumperLogContext logContext,
     IOptions<UpgradeOptions> options,
-    DotNetProcess dotNet,
+    DotNetProcess dotnet,
     ILogger<DotNetCodeUpgrader> logger) : FileUpgrader(console, environment, options, logger)
 {
     public override int Order => int.MaxValue; // Run after all other upgraders
@@ -90,7 +90,7 @@ internal sealed partial class DotNetCodeUpgrader(
         };
 
         // See https://learn.microsoft.com/dotnet/core/tools/dotnet-format#analyzers
-        var formatResult = await dotNet.RunAsync(
+        var formatResult = await dotnet.RunAsync(
             workingDirectory,
             arguments,
             environmentVariables,

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -23,7 +23,13 @@ internal sealed partial class DotNetCodeUpgrader(
 
     protected override string InitialStatus => "Update .NET code";
 
-    protected override IReadOnlyList<string> Patterns { get; } = ["*.sln", "*.csproj", "*.fsproj", "*.vbproj"];
+    protected override IReadOnlyList<string> Patterns { get; } =
+    [
+        WellKnownFileNames.SolutionFiles,
+        WellKnownFileNames.CSharpProjects,
+        WellKnownFileNames.FSharpProjects,
+        WellKnownFileNames.VisualBasicProjects,
+    ];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -99,9 +99,9 @@ internal sealed partial class DotNetCodeUpgrader(
         Dictionary<string, int> fixes = [];
         ProcessingResult result;
 
-        if (!string.IsNullOrEmpty(formatResult.StandardError))
+        if (!string.IsNullOrWhiteSpace(formatResult.StandardError))
         {
-            Log.DotNetFormatErrors(logger, formatResult.StandardError);
+            Log.DotNetFormatErrors(logger, formatResult.StandardError.TrimEnd());
         }
 
         if (formatResult.Success)

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -116,6 +116,7 @@ internal sealed partial class DotNetCodeUpgrader(
         var workingDirectory = Path.GetDirectoryName(projectOrSolution)!;
         using var tempDirectory = new TemporaryDirectory();
 
+        // See https://learn.microsoft.com/dotnet/core/tools/dotnet-format#analyzers
         string[] arguments =
         [
             "format",
@@ -130,7 +131,6 @@ internal sealed partial class DotNetCodeUpgrader(
 
         var environmentVariables = GetFormatEnvironment(sdkVersion);
 
-        // See https://learn.microsoft.com/dotnet/core/tools/dotnet-format#analyzers
         var formatResult = await dotnet.RunAsync(
             workingDirectory,
             arguments,

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using MartinCostello.DotNetBumper.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+internal sealed partial class DotNetCodeUpgrader(
+    IAnsiConsole console,
+    IEnvironment environment,
+    BumperLogContext logContext,
+    IOptions<UpgradeOptions> options,
+    DotNetProcess dotNet,
+    ILogger<DotNetCodeUpgrader> logger) : FileUpgrader(console, environment, options, logger)
+{
+    public override int Order => int.MaxValue; // Run after all other upgraders
+
+    protected override string Action => "Upgrading .NET code";
+
+    protected override string InitialStatus => "Update .NET code";
+
+    protected override IReadOnlyList<string> Patterns => ["*.sln", "*.csproj", "*.fsproj", "*.vbproj"];
+
+    protected override async Task<ProcessingResult> UpgradeCoreAsync(
+        UpgradeInfo upgrade,
+        IReadOnlyList<string> fileNames,
+        StatusContext context,
+        CancellationToken cancellationToken)
+    {
+        Log.UpgradingDotNetCode(Logger);
+
+        var diagnostics = new Dictionary<string, int>();
+        var result = ProcessingResult.None;
+
+        foreach (var fileName in fileNames)
+        {
+            var relativePath = PathHelpers.Normalize(RelativeName(fileName));
+            context.Status = StatusMessage($"Updating .NET code for {relativePath}...");
+
+            (var fileResult, var fixes) = await ApplyFixesAsync(fileName, cancellationToken);
+
+            foreach ((var diagnosticId, var count) in fixes)
+            {
+                if (!diagnostics.TryGetValue(diagnosticId, out var existing))
+                {
+                    existing = 0;
+                }
+
+                diagnostics[diagnosticId] = existing + count;
+            }
+
+            result = result.Max(fileResult);
+        }
+
+        foreach ((var diagnosticId, var count) in diagnostics.Where((p) => p.Value is not 0).OrderBy((p) => p.Key))
+        {
+            logContext.Changelog.Add($"Fix {diagnosticId} warning{(count is 1 ? string.Empty : "s")}");
+        }
+
+        return result;
+    }
+
+    private async Task<(ProcessingResult Result, Dictionary<string, int> Fixes)> ApplyFixesAsync(
+        string projectOrSolution,
+        CancellationToken cancellationToken)
+    {
+        var workingDirectory = Path.GetDirectoryName(projectOrSolution)!;
+        using var tempDirectory = new TemporaryDirectory();
+
+        string[] arguments =
+        [
+            "format",
+            "analyzers",
+            "--report",
+            tempDirectory.Path,
+            "--severity",
+            "warn",
+            "--verbosity",
+            "normal",
+        ];
+
+        // HACK Ignore CA1515 from .NET 9 as it seems to just break things
+        var environmentVariables = new Dictionary<string, string?>()
+        {
+            ["NoWarn"] = "CA1515",
+        };
+
+        // See https://learn.microsoft.com/dotnet/core/tools/dotnet-format#analyzers
+        var formatResult = await dotNet.RunAsync(
+            workingDirectory,
+            arguments,
+            environmentVariables,
+            cancellationToken);
+
+        Dictionary<string, int> fixes = [];
+        ProcessingResult result;
+
+        if (formatResult.Success)
+        {
+            int fixCount = 0;
+            string reportPath = Path.Combine(tempDirectory.Path, "format-report.json");
+
+            if (File.Exists(reportPath))
+            {
+                fixes = await GetFixesAsync(reportPath, cancellationToken);
+                fixCount += fixes.Sum((p) => p.Value);
+            }
+
+            result = fixCount is 0 ? ProcessingResult.None : ProcessingResult.Success;
+        }
+        else
+        {
+            string[] warnings =
+            [
+                $"Failed to apply .NET code updates for {RelativeName(workingDirectory)}.",
+                $"dotnet format exited with code {formatResult.ExitCode}.",
+            ];
+
+            Console.WriteLine();
+
+            foreach (var warning in warnings)
+            {
+                Console.WriteWarningLine(warning);
+                logContext.Warnings.Add(warning);
+            }
+
+            result = ProcessingResult.Warning;
+        }
+
+        return (result, fixes);
+    }
+
+    private async Task<Dictionary<string, int>> GetFixesAsync(string path, CancellationToken cancellationToken)
+    {
+        using var stream = File.OpenRead(path);
+        using var report = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+
+        var fixes = new Dictionary<string, int>();
+
+        if (report.RootElement.ValueKind is JsonValueKind.Array)
+        {
+            List<DiagnosticFix> diagnostics = [];
+
+            foreach (var document in report.RootElement.EnumerateArray())
+            {
+                if (!document.TryGetProperty("FileChanges", out var fileChanges) ||
+                    fileChanges.ValueKind is not JsonValueKind.Array)
+                {
+                    continue;
+                }
+
+                var filePath = document.GetProperty("FilePath").GetString();
+                var relativePath = RelativeName(filePath!);
+
+                foreach (var change in fileChanges.EnumerateArray())
+                {
+                    var diagnosticId = change.GetProperty("DiagnosticId").GetString()!;
+                    var lineNumber = change.GetProperty("LineNumber").GetInt32();
+
+                    diagnostics.Add(new(relativePath, diagnosticId, lineNumber));
+                }
+            }
+
+            // The diagnostics from the report are grouped to prevent duplication when multi-targeting
+            foreach ((var filePath, var diagnosticId, var lineNumber) in diagnostics.Distinct())
+            {
+                Log.FixedDiagnostic(Logger, diagnosticId, filePath, lineNumber);
+
+                if (!fixes.TryGetValue(diagnosticId, out var count))
+                {
+                    count = 0;
+                }
+
+                fixes[diagnosticId] = count + 1;
+            }
+        }
+
+        return fixes;
+    }
+
+    private record struct DiagnosticFix(string FilePath, string DiagnosticId, int LineNumber);
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 1,
+            Level = LogLevel.Debug,
+            Message = "Upgrading .NET code.")]
+        public static partial void UpgradingDotNetCode(ILogger logger);
+
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Debug,
+            Message = "Fixed diagnostic {DiagnosticId} in {FileName}:{LineNumber}.")]
+        public static partial void FixedDiagnostic(ILogger logger, string diagnosticId, string fileName, int lineNumber);
+    }
+}

--- a/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
@@ -24,7 +24,7 @@ internal sealed partial class GlobalJsonUpgrader(
 
     protected override string InitialStatus => "Update SDK version";
 
-    protected override IReadOnlyList<string> Patterns { get; } = ["global.json"];
+    protected override IReadOnlyList<string> Patterns { get; } = [WellKnownFileNames.GlobalJson];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
@@ -68,6 +68,8 @@ internal sealed partial class GlobalJsonUpgrader(
                     currentVersion.ToString(),
                     upgrade.SdkVersion.ToString());
 
+                logContext.DotNetSdkVersion = upgrade.SdkVersion.ToString();
+
                 result = result.Max(ProcessingResult.Success);
             }
         }

--- a/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
@@ -24,7 +24,7 @@ internal sealed partial class GlobalJsonUpgrader(
 
     protected override string InitialStatus => "Update SDK version";
 
-    protected override IReadOnlyList<string> Patterns => ["global.json"];
+    protected override IReadOnlyList<string> Patterns { get; } = ["global.json"];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -64,7 +64,7 @@ internal sealed partial class PackageVersionUpgrader(
 
     private static HiddenFile? TryHideGlobalJson(string path)
     {
-        var globalJson = FileHelpers.FindFileInProject(path, "global.json");
+        var globalJson = FileHelpers.FindFileInProject(path, WellKnownFileNames.GlobalJson);
 
         if (globalJson != null)
         {
@@ -76,7 +76,7 @@ internal sealed partial class PackageVersionUpgrader(
 
     private static HiddenFile? TryDotNetToolManifest(string path)
     {
-        var toolManifest = FileHelpers.FindFileInProject(path, Path.Join(".config", "dotnet-tools.json"));
+        var toolManifest = FileHelpers.FindFileInProject(path, Path.Join(".config", WellKnownFileNames.ToolsManifest));
 
         if (toolManifest != null)
         {

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -18,7 +18,7 @@ internal sealed partial class PackageVersionUpgrader(
     IOptions<UpgradeOptions> options,
     ILogger<PackageVersionUpgrader> logger) : Upgrader(console, environment, options, logger)
 {
-    public override int Order => int.MaxValue; // Packages need to be updated after the TFM so the packages relate to the update
+    public override int Order => int.MaxValue - 1; // Packages need to be updated after the TFM so the packages relate to the update but before C# updates
 
     protected override string Action => "Upgrading NuGet packages";
 

--- a/src/DotNetBumper.Core/Upgraders/PowerShellScriptUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PowerShellScriptUpgrader.cs
@@ -19,7 +19,7 @@ internal sealed partial class PowerShellScriptUpgrader(
 
     protected override string InitialStatus => "Update PowerShell scripts";
 
-    protected override IReadOnlyList<string> Patterns => ["*.ps1", "*.yaml", "*.yml"];
+    protected override IReadOnlyList<string> Patterns { get; } = ["*.ps1", "*.yaml", "*.yml"];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/RuntimeIdentifierUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/RuntimeIdentifierUpgrader.cs
@@ -20,7 +20,7 @@ internal sealed partial class RuntimeIdentifierUpgrader(
 
     protected override string InitialStatus => "Update RIDs";
 
-    protected override IReadOnlyList<string> Patterns { get; } = ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml"];
+    protected override IReadOnlyList<string> Patterns { get; } = ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml", "*.vbproj"];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/RuntimeIdentifierUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/RuntimeIdentifierUpgrader.cs
@@ -20,7 +20,7 @@ internal sealed partial class RuntimeIdentifierUpgrader(
 
     protected override string InitialStatus => "Update RIDs";
 
-    protected override IReadOnlyList<string> Patterns => ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml"];
+    protected override IReadOnlyList<string> Patterns { get; } = ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml"];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/RuntimeIdentifierUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/RuntimeIdentifierUpgrader.cs
@@ -20,7 +20,14 @@ internal sealed partial class RuntimeIdentifierUpgrader(
 
     protected override string InitialStatus => "Update RIDs";
 
-    protected override IReadOnlyList<string> Patterns { get; } = ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml", "*.vbproj"];
+    protected override IReadOnlyList<string> Patterns { get; } =
+    [
+        WellKnownFileNames.DirectoryBuildProps,
+        WellKnownFileNames.CSharpProjects,
+        WellKnownFileNames.FSharpProjects,
+        WellKnownFileNames.PublishProfiles,
+        WellKnownFileNames.VisualBasicProjects,
+    ];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/ServerlessUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/ServerlessUpgrader.cs
@@ -24,7 +24,7 @@ internal sealed partial class ServerlessUpgrader(
 
     protected override string InitialStatus => "Update Serverless runtimes";
 
-    protected override IReadOnlyList<string> Patterns => ["serverless.yml", "serverless.yaml"];
+    protected override IReadOnlyList<string> Patterns { get; } = ["serverless.yml", "serverless.yaml"];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
@@ -20,7 +20,7 @@ internal sealed partial class TargetFrameworkUpgrader(
 
     protected override string InitialStatus => "Update TFMs";
 
-    protected override IReadOnlyList<string> Patterns => ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml"];
+    protected override IReadOnlyList<string> Patterns { get; } = ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml"];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
@@ -20,7 +20,7 @@ internal sealed partial class TargetFrameworkUpgrader(
 
     protected override string InitialStatus => "Update TFMs";
 
-    protected override IReadOnlyList<string> Patterns { get; } = ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml"];
+    protected override IReadOnlyList<string> Patterns { get; } = ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml", "*.vbproj"];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/TargetFrameworkUpgrader.cs
@@ -20,7 +20,14 @@ internal sealed partial class TargetFrameworkUpgrader(
 
     protected override string InitialStatus => "Update TFMs";
 
-    protected override IReadOnlyList<string> Patterns { get; } = ["Directory.Build.props", "*.csproj", "*.fsproj", "*.pubxml", "*.vbproj"];
+    protected override IReadOnlyList<string> Patterns { get; } =
+    [
+        WellKnownFileNames.DirectoryBuildProps,
+        WellKnownFileNames.CSharpProjects,
+        WellKnownFileNames.FSharpProjects,
+        WellKnownFileNames.PublishProfiles,
+        WellKnownFileNames.VisualBasicProjects,
+    ];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/Upgraders/VisualStudioCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/VisualStudioCodeUpgrader.cs
@@ -22,7 +22,7 @@ internal sealed partial class VisualStudioCodeUpgrader(
 
     protected override string InitialStatus => "Update Visual Studio Code configuration";
 
-    protected override IReadOnlyList<string> Patterns => ["launch.json"];
+    protected override IReadOnlyList<string> Patterns { get; } = ["launch.json"];
 
     protected override IReadOnlyList<string> FindFiles()
     {

--- a/src/DotNetBumper.Core/Upgraders/VisualStudioComponentUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/VisualStudioComponentUpgrader.cs
@@ -20,7 +20,7 @@ internal sealed partial class VisualStudioComponentUpgrader(
 
     protected override string InitialStatus => "Update Visual Studio configuration";
 
-    protected override IReadOnlyList<string> Patterns => [".vsconfig"];
+    protected override IReadOnlyList<string> Patterns { get; } = [".vsconfig"];
 
     protected override async Task<ProcessingResult> UpgradeCoreAsync(
         UpgradeInfo upgrade,

--- a/src/DotNetBumper.Core/WellKnownFileNames.cs
+++ b/src/DotNetBumper.Core/WellKnownFileNames.cs
@@ -3,7 +3,7 @@
 
 namespace MartinCostello.DotNetBumper;
 
-internal class WellKnownFileNames
+internal static class WellKnownFileNames
 {
     public const string CSharpProjects = "*.csproj";
     public const string FSharpProjects = "*.fsproj";

--- a/src/DotNetBumper.Core/WellKnownFileNames.cs
+++ b/src/DotNetBumper.Core/WellKnownFileNames.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper;
+
+internal class WellKnownFileNames
+{
+    public const string CSharpProjects = "*.csproj";
+    public const string FSharpProjects = "*.fsproj";
+    public const string VisualBasicProjects = "*.vbproj";
+    public const string PublishProfiles = "*.pubxml";
+    public const string SolutionFiles = "*.sln";
+
+    public const string DirectoryBuildProps = "Directory.Build.props";
+    public const string GlobalJson = "global.json";
+    public const string ToolsManifest = "dotnet-tools.json";
+}

--- a/src/DotNetBumper/DotNetBumper.csproj
+++ b/src/DotNetBumper/DotNetBumper.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.4.1</PackageValidationBaselineVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DotNetBumper.Core\DotNetBumper.Core.csproj" />

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -50,8 +50,11 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
 
         fixture.Project.AddGitRepository();
         await fixture.Project.AddGitIgnoreAsync();
+        await fixture.Project.AddEditorConfigAsync();
 
         await fixture.Project.AddSolutionAsync("Project.sln");
+
+        await fixture.Project.AddDirectoryBuildPropsAsync();
         await fixture.Project.AddToolManifestAsync();
 
         string globalJson = await fixture.Project.AddGlobalJsonAsync(testCase.SdkVersion);

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -106,8 +106,8 @@ internal sealed class Project : IDisposable
 
     public async Task<string> AddToolManifestAsync(string path = ".config/dotnet-tools.json")
     {
+        /*lang=json,strict*/
         var manifest =
-            /*lang=json,strict*/
             """
             {
               "version": 1,

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -289,7 +289,8 @@ internal sealed class Project : IDisposable
                 <AnalysisMode>All</AnalysisMode>
                 <EnableNETAnalyzers>true</EnableNETAnalyzers>
                 <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-                <NoWarn>$(NoWarn);CA1002</NoWarn>
+                <GenerateDocumentationFile>true</GenerateDocumentationFile>
+                <NoWarn>$(NoWarn);CA1002;CS419;CS1570;CS1573;CS1574;CS1584;CS1591</NoWarn>
               </PropertyGroup>
             </Project>
             """;

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -280,20 +280,25 @@ internal sealed class Project : IDisposable
         await AddFileAsync(".editorconfig", editorconfig);
     }
 
-    public async Task AddDirectoryBuildPropsAsync(string? properties = null)
+    public async Task AddDirectoryBuildPropsAsync(
+        string? noWarn = null,
+        bool treatWarningsAsErrors = false)
     {
-        properties ??=
-            """
-            <Project>
-              <PropertyGroup>
-                <AnalysisMode>All</AnalysisMode>
-                <EnableNETAnalyzers>true</EnableNETAnalyzers>
-                <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-                <GenerateDocumentationFile>true</GenerateDocumentationFile>
-                <NoWarn>$(NoWarn);CA1002;CS419;CS1570;CS1573;CS1574;CS1584;CS1591</NoWarn>
-              </PropertyGroup>
-            </Project>
-            """;
+#pragma warning disable CA1308
+        string properties =
+            $"""
+             <Project>
+               <PropertyGroup>
+                 <AnalysisMode>All</AnalysisMode>
+                 <EnableNETAnalyzers>true</EnableNETAnalyzers>
+                 <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+                 <GenerateDocumentationFile>true</GenerateDocumentationFile>
+                 <NoWarn>$(NoWarn);{noWarn ?? "CA1002;CS419;CS1570;CS1573;CS1574;CS1584;CS1591"}</NoWarn>
+                 <TreatWarningsAsErrors>{treatWarningsAsErrors.ToString().ToLowerInvariant()}</TreatWarningsAsErrors>
+               </PropertyGroup>
+             </Project>
+             """;
+#pragma warning restore CA1308
 
         await AddFileAsync("Directory.Build.props", properties);
     }

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -159,7 +159,7 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
 
-        using var fixture = await CreateFixtureAsync(upgrade, severity: "information");
+        using var fixture = await CreateFixtureAsync(upgrade, severity: "info");
 
         string code =
             """

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
+{
+#pragma warning disable IDE0028 // See https://github.com/dotnet/roslyn/issues/72668
+    public static TheoryData<string> Channels()
+    {
+        return new()
+        {
+            "7.0",
+            "8.0",
+            //// "9.0", See https://github.com/dotnet/sdk/issues/39909
+        };
+#pragma warning restore IDE0028
+    }
+
+    [Theory]
+    [MemberData(nameof(Channels))]
+    public async Task UpgradeAsync_Applies_Code_Fix(string channel)
+    {
+        // Arrange
+        var upgrade = await GetUpgradeAsync(channel);
+
+        string code =
+            """
+            namespace Project;
+
+            public class Person
+            {
+                public string Name { get; set; } = string.Empty;
+
+                public string TruncateName(int length) => Name.Substring(0, length); // IDE0057
+            }
+            """;
+
+        string editorconfig =
+            """
+            root = true
+            
+            [*]
+            end_of_line = lf
+            indent_size = 4
+            indent_style = space
+            insert_final_newline = true
+            trim_trailing_whitespace = true
+            
+            [*.{cs,vb}]
+            dotnet_analyzer_diagnostic.category-Style.severity = warning
+            
+            [*.cs]
+            csharp_style_expression_bodied_methods = when_on_single_line
+            csharp_style_namespace_declarations = file_scoped
+            """;
+
+        string properties =
+            """
+            <Project>
+              <PropertyGroup>
+                <AnalysisMode>All</AnalysisMode>
+                <EnableGenerateDocumentationFile>true</EnableGenerateDocumentationFile>
+                <EnableNETAnalyzers>true</EnableNETAnalyzers>
+                <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+              </PropertyGroup>
+            </Project>
+            """;
+
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        await fixture.Project.AddApplicationProjectAsync([$"net{channel}"]);
+        await fixture.Project.AddDirectoryBuildPropsAsync(properties);
+        await fixture.Project.AddEditorConfigAsync(editorconfig);
+        await fixture.Project.AddFileAsync("src/Project/Person.cs", code);
+        await fixture.Project.AddGlobalJsonAsync(upgrade.SdkVersion.ToString());
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBe(ProcessingResult.Success);
+        fixture.LogContext.Changelog.ShouldContain("Fix IDE0057 warning");
+
+        // Act
+        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBe(ProcessingResult.None);
+    }
+
+    private static DotNetCodeUpgrader CreateTarget(UpgraderFixture fixture)
+    {
+        return new(
+            new(fixture.CreateLogger<DotNetProcess>()),
+            fixture.Console,
+            fixture.Environment,
+            fixture.LogContext,
+            fixture.CreateOptions(),
+            fixture.CreateLogger<DotNetCodeUpgrader>());
+    }
+
+    private async Task<UpgradeInfo> GetUpgradeAsync(string channel)
+    {
+        // Use the same SDK version as the upgrade to prevent a different dotnet format version being used
+        var finder = new DotNetUpgradeFinder(
+            new HttpClient(),
+            Microsoft.Extensions.Options.Options.Create(new UpgradeOptions() { DotNetChannel = channel }),
+            outputHelper.ToLogger<DotNetUpgradeFinder>());
+
+        var upgrade = await finder.GetUpgradeAsync(CancellationToken.None);
+        upgrade.ShouldNotBeNull();
+
+        return upgrade;
+    }
+}

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -28,10 +28,17 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
             """
             namespace Project;
 
+            /// <summary>
+            /// A person.
+            /// </summary>
             public class Person
             {
+                /// <summary>Gets or sets the name of the person.</summary>
                 public string Name { get; set; } = string.Empty;
 
+                /// <summary>Truncates the name to the specified length.</summary>
+                /// <param name="length">The length to truncate the name to.</param>
+                /// <returns>The truncated name.</returns>
                 public string TruncateName(int length) => Name.Substring(0, length); // IDE0057
             }
             """;

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -60,9 +60,9 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
             <Project>
               <PropertyGroup>
                 <AnalysisMode>All</AnalysisMode>
-                <EnableGenerateDocumentationFile>true</EnableGenerateDocumentationFile>
                 <EnableNETAnalyzers>true</EnableNETAnalyzers>
                 <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+                <GenerateDocumentationFile>true</GenerateDocumentationFile>
               </PropertyGroup>
             </Project>
             """;

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -11,7 +11,7 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
         return new()
         {
             "7.0",
-            "8.0",
+            //// "8.0", See https://github.com/dotnet/sdk/issues/39742
             //// "9.0", See https://github.com/dotnet/sdk/issues/39909
         };
 #pragma warning restore IDE0028


### PR DESCRIPTION
- Apply code fixes from analyzers for warnings and errors using `dotnet format`.
- Include `.vbproj` files in the scope of some of the existing upgraders.
- Fix `ArgumentException` when parsing test logs.

Resolves #31.
Resolves #143.
