### PR TITLE
Add integration tests workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -80,13 +80,13 @@ jobs:
       fail-fast: false
       matrix:
         repo:
-          - martincostello/adventofcode
-          - martincostello/alexa-london-travel
-          - martincostello/alexa-london-travel-site
-          - martincostello/costellobot
-          - martincostello/dependabot-helper
-          - martincostello/dotnet-bumper
-          - martincostello/website
+          - adventofcode
+          - alexa-london-travel
+          - alexa-london-travel-site
+          - costellobot
+          - dependabot-helper
+          - dotnet-bumper
+          - website
         upgrade-type:
           - Lts
           - Latest
@@ -117,10 +117,10 @@ jobs:
         dotnet tool install --global dotnet-outdated-tool --version ${env:DOTNET_OUTDATED_VERSION}
         dotnet tool install --global MartinCostello.DotNetBumper --add-source ./packages --prerelease
 
-    - name: Checkout ${{ matrix.repo }}
+    - name: Checkout ${{ github.repository_owner }}/${{ matrix.repo }}
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       with:
-        repository: ${{ matrix.repo }}
+        repository: "${{ github.repository_owner }}/${{ matrix.repo }}"
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,6 +32,9 @@ jobs:
   package:
     runs-on: ubuntu-latest
 
+    outputs:
+      dotnet-outdated-version: ${{ steps.get-dotnet-outdated-version.outputs.dotnet-outdated-version }}
+
     steps:
 
     - name: Checkout code
@@ -61,6 +64,13 @@ jobs:
         name: packages
         path: ./artifacts/package/release
         if-no-files-found: error
+
+    - name: Get dotnet-outdated version
+      id: get-dotnet-outdated-version
+      shell: pwsh
+      run: |
+        $dotnetOutdatedVersion = (Get-Content "./.config/dotnet-tools.json" | Out-String | ConvertFrom-Json).tools.'dotnet-outdated-tool'.version
+        "dotnet-outdated-version=${dotnetOutdatedVersion}" >> $env:GITHUB_OUTPUT
 
   test:
     needs: [ package ]
@@ -101,7 +111,10 @@ jobs:
 
     - name: Install .NET Bumper
       shell: pwsh
+      env:
+        DOTNET_OUTDATED_VERSION: ${{ needs.package.outputs.dotnet-outdated-version }}
       run: |
+        dotnet tool install --global dotnet-outdated-tool --version ${env:DOTNET_OUTDATED_VERSION}
         dotnet tool install --global MartinCostello.DotNetBumper --add-source ./packages --prerelease
 
     - name: Checkout ${{ matrix.repo }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,121 @@
+name: integration-tests
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**/*.gitattributes'
+      - '**/*.gitignore'
+      - '**/*.md'
+  pull_request:
+    branches:
+      - main
+      - dotnet-vnext
+      - dotnet-nightly
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_GENERATE_ASPNET_CERTIFICATE: false
+  DOTNET_MULTILEVEL_LOOKUP: 0
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  FORCE_COLOR: 3
+  NUGET_XMLDOC_MODE: skip
+  TERM: xterm
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+    - name: Install .NET SDKs
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+      with:
+        dotnet-version: |
+          6.0.x
+          7.0.x
+          8.0.x
+          9.0.x
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+
+    - name: Publish NuGet package
+      shell: pwsh
+      run: |
+        dotnet tool restore
+        dotnet pack
+
+    - name: Publish NuGet packages
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: packages
+        path: ./artifacts/package/release
+        if-no-files-found: error
+
+  test:
+    needs: [ package ]
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - martincostello/adventofcode
+          - martincostello/alexa-london-travel
+          - martincostello/alexa-london-travel-site
+          - martincostello/costellobot
+          - martincostello/dependabot-helper
+          - martincostello/dotnet-bumper
+          - martincostello/website
+        upgrade-type:
+          - Lts
+          - Latest
+          - Preview
+
+    steps:
+
+    - name: Download packages
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+      with:
+        name: packages
+        path: ./packages
+
+    - name: Install .NET SDKs
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+      with:
+        dotnet-version: |
+          6.0.x
+          7.0.x
+          8.0.x
+          9.0.x
+
+    - name: Install .NET Bumper
+      shell: pwsh
+      run: |
+        dotnet tool install --global MartinCostello.DotNetBumper --add-source ./packages --prerelease
+
+    - name: Checkout ${{ matrix.repo }}
+      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      with:
+        repository: ${{ matrix.repo }}
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+
+    - name: Run .NET Bumper
+      shell: pwsh
+      env:
+        DOTNET_BUMPER_UPGRADE_TYPE: ${{ matrix.upgrade-type }}
+        NoWarn: 'CA1515'
+      run: |
+        dotnet bumper . --log-format GitHubActions --test --upgrade-type ${env:DOTNET_BUMPER_UPGRADE_TYPE}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -162,3 +162,10 @@ jobs:
           $bumperArgs += ${env:DOTNET_BUMPER_CONFIG}
         }
         dotnet bumper $bumperArgs
+
+  integration-tests:
+    needs: [ package, test ]
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo 'Integration tests successful ✅'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -125,10 +125,40 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
 
+    - name: Create .NET Bumper config file if no custom config
+      id: generate-config
+      shell: pwsh
+      run: |
+        $configFile = ""
+        $hasConfigFile = ((Test-Path -Path ".dotnet-bumper.json") -Or (Test-Path -Path ".dotnet-bumper.yml")) -Or (Test-Path -Path ".dotnet-bumper.yaml")
+        if (-Not $hasConfigFile) {
+          $tempFile = [System.IO.Path]::GetTempFileName()
+          $config = @{
+            noWarn = @(
+              'CA1515'
+            )
+          }
+          $config | ConvertTo-Json | Out-File -FilePath $tempFile | Out-Null
+        }
+        "dotnet-bumper-config=${configFile}" >> $env:GITHUB_OUTPUT
+
     - name: Run .NET Bumper
       shell: pwsh
       env:
+        DOTNET_BUMPER_CONFIG: ${{ steps.generate-config.outputs.dotnet-bumper-config }}
         DOTNET_BUMPER_UPGRADE_TYPE: ${{ matrix.upgrade-type }}
         NoWarn: 'CA1515'
       run: |
-        dotnet bumper . --log-format GitHubActions --test --upgrade-type ${env:DOTNET_BUMPER_UPGRADE_TYPE}
+        $bumperArgs = @(
+          ".",
+          "--log-format",
+          "GitHubActions",
+          "--test",
+          "--upgrade-type",
+          ${env:DOTNET_BUMPER_UPGRADE_TYPE}
+        )
+        if (-Not [string]::IsNullOrEmpty(${env:DOTNET_BUMPER_CONFIG})) {
+          $bumperArgs += "--configuration-file"
+          $bumperArgs += ${env:DOTNET_BUMPER_CONFIG}
+        }
+        dotnet bumper $bumperArgs

--- a/DotNetBumper.ruleset
+++ b/DotNetBumper.ruleset
@@ -10,6 +10,7 @@
     <Rule Id="CA1056" Action="None" />
     <Rule Id="CA1062" Action="None" />
     <Rule Id="CA1303" Action="None" />
+    <Rule Id="CA1515" Action="None" />
     <Rule Id="CA1707" Action="None" />
     <Rule Id="CA1711" Action="None" />
     <Rule Id="CA1720" Action="None" />

--- a/DotNetBumper.sln
+++ b/DotNetBumper.sln
@@ -15,6 +15,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetBumper.Tests", "tests
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4CFD8621-B558-4A35-8780-E56A3C5F29CB}"
 	ProjectSection(SolutionItems) = preProject
+		.dotnet-bumper.json = .dotnet-bumper.json
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore

--- a/src/DotNetBumper.Core/Logging/MarkdownLogWriter.cs
+++ b/src/DotNetBumper.Core/Logging/MarkdownLogWriter.cs
@@ -24,6 +24,11 @@ internal class MarkdownLogWriter(string fileName) : FileLogWriter(fileName)
 
             await writer.WriteLineAsync();
         }
+        else if (context.Result is nameof(ProcessingResult.None))
+        {
+            await writer.WriteLineAsync("The project upgrade did not result in any changes being made.");
+            await writer.WriteLineAsync();
+        }
         else if (context.DotNetSdkVersion is not null)
         {
             await writer.WriteLineAsync($"Project upgraded to .NET SDK `{context.DotNetSdkVersion}`.");

--- a/tests/DotNetBumper.Tests/Logging/MarkdownLogWriterTests.cs
+++ b/tests/DotNetBumper.Tests/Logging/MarkdownLogWriterTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper.Logging;
+
+public static class MarkdownLogWriterTests
+{
+    [Fact]
+    public static async Task WriteAsync_Generates_Log_File_When_Successful()
+    {
+        // Arrange
+        var context = new BumperLogContext()
+        {
+            DotNetSdkVersion = "8.0.201",
+            StartedAt = new(2024, 02, 27, 12, 34, 56, TimeSpan.Zero),
+            FinishedAt = new(2024, 02, 27, 12, 35, 43, TimeSpan.Zero),
+            Result = nameof(ProcessingResult.Success),
+        };
+
+        var path = Path.GetTempFileName();
+        var target = new MarkdownLogWriter(path);
+
+        // Act
+        await target.WriteAsync(context, CancellationToken.None);
+
+        // Assert
+        File.Exists(path).ShouldBeTrue();
+
+        var contents = await File.ReadAllTextAsync(path);
+        contents.Length.ShouldBeGreaterThan(0);
+
+        contents.ShouldContain("Project upgraded to .NET SDK `8.0.201`.");
+    }
+
+    [Fact]
+    public static async Task WriteAsync_Generates_Log_File_When_No_Upgrade()
+    {
+        // Arrange
+        var context = new BumperLogContext()
+        {
+            DotNetSdkVersion = "8.0.201",
+            StartedAt = new(2024, 02, 27, 12, 34, 56, TimeSpan.Zero),
+            FinishedAt = new(2024, 02, 27, 12, 35, 43, TimeSpan.Zero),
+            Result = nameof(ProcessingResult.None),
+        };
+
+        var path = Path.GetTempFileName();
+        var target = new MarkdownLogWriter(path);
+
+        // Act
+        await target.WriteAsync(context, CancellationToken.None);
+
+        // Assert
+        File.Exists(path).ShouldBeTrue();
+
+        var contents = await File.ReadAllTextAsync(path);
+        contents.Length.ShouldBeGreaterThan(0);
+
+        contents.ShouldContain("The project upgrade did not result in any changes being made.");
+    }
+}


### PR DESCRIPTION
- Add a GitHub Actions workflow that publishes the NuGet package and then runs integration tests by running .NET Bumper against the specified repositories.
- Fix the Markdown output log incorrectly containing details about a .NET SDK upgrade if nothing was upgraded.
- Disable the new .NET 9 CA1515 analyser warning.
