### PR TITLE
Fix NoWarn with dotnet test

### DIFF
--- a/.dotnet-bumper.json
+++ b/.dotnet-bumper.json
@@ -3,6 +3,9 @@
   "excludeNuGetPackages": [
     "System.Text.Json"
   ],
+  "noWarn": [
+    "CA1515"
+  ],
   "remainingReferencesIgnore": [
     "docs/demo.yml",
     "tests/DotNetBumper.Tests/**/*.cs"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,7 +91,7 @@ jobs:
           - project-euler
           - website
         upgrade-type:
-          - Lts
+          - LTS
           - Latest
           - Preview
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -84,9 +84,11 @@ jobs:
           - alexa-london-travel
           - alexa-london-travel-site
           - api
+          - apple-fitness-workout-mapper
           - costellobot
           - dependabot-helper
           - dotnet-bumper
+          - project-euler
           - website
         upgrade-type:
           - Lts

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -145,6 +145,7 @@ jobs:
             )
           }
           $config | ConvertTo-Json | Out-File -FilePath $tempFile | Out-Null
+          $configFile = $tempFile
         }
         "dotnet-bumper-config=${configFile}" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -83,6 +83,7 @@ jobs:
           # - adventofcode HACK Disabled due to https://github.com/dotnet/sdk/issues/39909
           - alexa-london-travel
           - alexa-london-travel-site
+          - api
           - costellobot
           - dependabot-helper
           - dotnet-bumper
@@ -152,7 +153,6 @@ jobs:
       env:
         DOTNET_BUMPER_CONFIG: ${{ steps.generate-config.outputs.dotnet-bumper-config }}
         DOTNET_BUMPER_UPGRADE_TYPE: ${{ matrix.upgrade-type }}
-        NoWarn: 'CA1515'
       run: |
         $bumperArgs = @(
           ".",

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,10 @@
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <AssemblyVersion>0.5.0.0</AssemblyVersion>
     <VersionPrefix>0.5.2</VersionPrefix>
-    <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' ">
+    <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_HEAD_REF)' == '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>
+    <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_HEAD_REF)' != '' ">pr.$(GITHUB_REF_NAME.Replace('/merge', '')).$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>
     <FileVersion Condition=" '$(GITHUB_RUN_NUMBER)' != '' ">$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>

--- a/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
@@ -1,0 +1,175 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using MartinCostello.DotNetBumper.Upgraders;
+using NSubstitute;
+
+namespace MartinCostello.DotNetBumper.PostProcessors;
+
+public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
+{
+    public static TheoryData<string> Channels()
+    {
+#pragma warning disable IDE0028 // See https://github.com/dotnet/roslyn/issues/72668
+        return new()
+        {
+            "7.0",
+            "8.0",
+            "9.0",
+        };
+#pragma warning restore IDE0028
+    }
+
+    [Theory]
+    [MemberData(nameof(Channels))]
+    public async Task PostProcessAsync_Succeeds_When_No_DirectoryBuildProps(string channel)
+    {
+        // Arrange
+        var upgrade = await GetUpgradeAsync(channel);
+
+        using var fixture = await CreateFixtureAsync(upgrade);
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.PostProcessAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actual.ShouldBe(ProcessingResult.Success);
+    }
+
+    [Theory]
+    [MemberData(nameof(Channels))]
+    public async Task PostProcessAsync_Succeeds_When_DirectoryBuildProps_Without_ArtifactsOutput(string channel)
+    {
+        // Arrange
+        var upgrade = await GetUpgradeAsync(channel);
+
+        using var fixture = await CreateFixtureAsync(upgrade);
+
+        await fixture.Project.AddDirectoryBuildPropsAsync();
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.PostProcessAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actual.ShouldBe(ProcessingResult.Success);
+    }
+
+    [Theory]
+    [InlineData("8.0", "", "")]
+    [InlineData("8.0", "false", "")]
+    [InlineData("8.0", "true", "")]
+    [InlineData("8.0", "true", "$(MSBuildThisFileDirectory)\\.artifacts")]
+    [InlineData("9.0", "", "")]
+    [InlineData("9.0", "false", "")]
+    [InlineData("9.0", "true", "")]
+    [InlineData("9.0", "true", "$(MSBuildThisFileDirectory)\\.artifacts")]
+    public async Task PostProcessAsync_Succeeds_When_DirectoryBuildProps_With_Artifacts_Output(
+        string channel,
+        string useArtifactsOutput,
+        string artifactsPath)
+    {
+        // Arrange
+        var upgrade = await GetUpgradeAsync(channel);
+
+        using var fixture = await CreateFixtureAsync(upgrade);
+
+        fixture.UserConfiguration.NoWarn = ["CA1002", "CA1515"];
+
+        string properties =
+            $"""
+             <Project>
+               <PropertyGroup>
+                 <AnalysisMode>All</AnalysisMode>
+                 <ArtifactsPath>{artifactsPath}</ArtifactsPath>
+                 <EnableNETAnalyzers>true</EnableNETAnalyzers>
+                 <NoWarn>$(NoWarn);CA1307;CA1309;CA1707</NoWarn>
+                 <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+                 <UseArtifactsOutput>{useArtifactsOutput}</UseArtifactsOutput>
+               </PropertyGroup>
+             </Project>
+             """;
+
+        await fixture.Project.AddFileAsync("Directory.Build.props", properties);
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.PostProcessAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actual.ShouldBe(ProcessingResult.Success);
+    }
+
+    private static DotNetTestPostProcessor CreateTarget(UpgraderFixture fixture)
+    {
+        var environment = Substitute.For<IEnvironment>();
+        environment.SupportsLinks.Returns(true);
+
+        var options = fixture.CreateOptions();
+        options.Value.TestUpgrade = true;
+
+        var configurationLoader = Substitute.For<BumperConfigurationLoader>(
+            options,
+            fixture.CreateLogger<BumperConfigurationLoader>());
+
+        configurationLoader.LoadAsync(Arg.Any<CancellationToken>())
+                           .Returns(fixture.UserConfiguration);
+
+        var configurationProvider = new BumperConfigurationProvider(
+            configurationLoader,
+            options,
+            fixture.CreateLogger<BumperConfigurationProvider>());
+
+        return new(
+            new(fixture.CreateLogger<DotNetProcess>()),
+            fixture.Console,
+            environment,
+            configurationProvider,
+            fixture.LogContext,
+            options,
+            fixture.CreateLogger<DotNetTestPostProcessor>());
+    }
+
+    private async Task<UpgradeInfo> GetUpgradeAsync(string channel)
+    {
+        // Use the same SDK version as the upgrade to prevent a different dotnet format version being used
+        var finder = new DotNetUpgradeFinder(
+            new HttpClient(),
+            Microsoft.Extensions.Options.Options.Create(new UpgradeOptions() { DotNetChannel = channel }),
+            outputHelper.ToLogger<DotNetUpgradeFinder>());
+
+        var upgrade = await finder.GetUpgradeAsync(CancellationToken.None);
+        upgrade.ShouldNotBeNull();
+
+        return upgrade;
+    }
+
+    private async Task<UpgraderFixture> CreateFixtureAsync(UpgradeInfo upgrade)
+    {
+        var fixture = new UpgraderFixture(outputHelper);
+
+        try
+        {
+            string[] targetFrameworks = [$"net{upgrade.Channel}"];
+
+            await fixture.Project.AddGitIgnoreAsync();
+
+            await fixture.Project.AddApplicationProjectAsync(targetFrameworks);
+            await fixture.Project.AddGlobalJsonAsync(upgrade.SdkVersion.ToString());
+
+            await fixture.Project.AddTestProjectAsync(targetFrameworks);
+            await fixture.Project.AddUnitTestsAsync();
+
+            return fixture;
+        }
+        catch (Exception)
+        {
+            fixture.Dispose();
+            throw;
+        }
+    }
+}

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -5,9 +5,9 @@ namespace MartinCostello.DotNetBumper.Upgraders;
 
 public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 {
-#pragma warning disable IDE0028 // See https://github.com/dotnet/roslyn/issues/72668
     public static TheoryData<string> Channels()
     {
+#pragma warning disable IDE0028 // See https://github.com/dotnet/roslyn/issues/72668
         return new()
         {
             "7.0",


### PR DESCRIPTION
- Fix `NoWarn` environment variable override not working with `dotnet test`.
- Fix incorrect warnings for unsupported .NET runtimes when upgrading SAM templates using custom runtimes.
