### PR TITLE
Specify --warnings-as-errors

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -87,21 +87,12 @@ jobs:
           - repo: alexa-london-travel
             test: false
             upgrade-type: LTS
-            warnings-as-errors: false
           - repo: alexa-london-travel
             test: false
             upgrade-type: Latest
-            warnings-as-errors: false
           - repo: alexa-london-travel
             test: false
             upgrade-type: Preview
-            warnings-as-errors: false
-          - repo: alexa-london-travel-site
-            upgrade-type: Preview
-            warnings-as-errors: false
-          - repo: dotnet-bumper
-            upgrade-type: Preview
-            warnings-as-errors: false
 
     steps:
 


### PR DESCRIPTION
Specify `--warnings-as-errors` in the integration tests to trap more possible issues.
