### PR TITLE
Fix flaky test

### DIFF
--- a/src/DotNetBumper.MSBuild/DotNetBumper.MSBuild.csproj
+++ b/src/DotNetBumper.MSBuild/DotNetBumper.MSBuild.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Library</OutputType>
     <PackageId>MartinCostello.DotNetBumper.MSBuild</PackageId>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <RootNamespace>MartinCostello.DotNetBumper</RootNamespace>
     <Summary>$(Description)</Summary>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/DotNetBumper.TestLogger/DotNetBumper.TestLogger.csproj
+++ b/src/DotNetBumper.TestLogger/DotNetBumper.TestLogger.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Library</OutputType>
     <PackageId>DotNetBumper.TestLogger</PackageId>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <RootNamespace>MartinCostello.DotNetBumper</RootNamespace>
     <Summary>$(Description)</Summary>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/tests/DotNetBumper.Tests/BumperTestLoggerTests.cs
+++ b/tests/DotNetBumper.Tests/BumperTestLoggerTests.cs
@@ -6,10 +6,10 @@ using NSubstitute;
 
 namespace MartinCostello.DotNetBumper;
 
-public class BumperTestLoggerTests
+public static class BumperTestLoggerTests
 {
     [Fact]
-    public void BumperTestLoggerTests_Initialize_Throws_If_No_Path_Specified()
+    public static void BumperTestLoggerTests_Initialize_Throws_If_No_Path_Specified()
     {
         // Arrange
         var events = Substitute.For<TestLoggerEvents>();
@@ -17,8 +17,20 @@ public class BumperTestLoggerTests
 
         var logger = new BumperTestLogger();
 
-        // Act and Assert
-        Should.Throw<InvalidOperationException>(
-            () => logger.Initialize(events, testRunDirectory));
+        const string VariableName = "MartinCostello_DotNetBumper_TestLogPath";
+        var existing = Environment.GetEnvironmentVariable(VariableName);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(VariableName, null);
+
+            // Act and Assert
+            Should.Throw<InvalidOperationException>(
+                () => logger.Initialize(events, testRunDirectory));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(VariableName, existing);
+        }
     }
 }

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -113,7 +113,7 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
         actual.ShouldBe(ProcessingResult.None);
     }
 
-    [Theory(Skip = "This test is flaky as sometimes on Windows dotnet format cannot find the .NET SDK.")]
+    [Theory]
     [MemberData(nameof(Channels))]
     public async Task UpgradeAsync_Honors_User_Project_Settings(string channel)
     {


### PR DESCRIPTION
Fix test that was failing because the environment variable had a value where it didn't before, likely because of some parallelism or re-ordering in .NET 9.
