### PR TITLE
Refactor tests

### DIFF
--- a/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
+++ b/src/DotNetBumper.Core/IAnsiConsoleExtensions.cs
@@ -67,7 +67,15 @@ public static class IAnsiConsoleExtensions
         double daysRemaining)
     {
         var eolUtc = upgrade.EndOfLife.GetValueOrDefault().ToDateTime(TimeOnly.MinValue);
-        console.WriteWarningLine($"Support for .NET {upgrade.Channel} ends in {daysRemaining:N0} days on {eolUtc:D}.");
+
+        if (daysRemaining > 0)
+        {
+            console.WriteWarningLine($"Support for .NET {upgrade.Channel} ends in {daysRemaining:N0} days on {eolUtc:D}.");
+        }
+        else
+        {
+            console.WriteWarningLine($"Support for .NET {upgrade.Channel} ended on {eolUtc:D}.");
+        }
 
         var supportPolicyTitle = ".NET and .NET Core Support Policy";
         var supportPolicyUrl = SupportPolicyUrl(upgrade.Channel);

--- a/tests/DotNetBumper.Tests/IAnsiConsoleExtensionsTests.cs
+++ b/tests/DotNetBumper.Tests/IAnsiConsoleExtensionsTests.cs
@@ -52,8 +52,11 @@ public static class IAnsiConsoleExtensionsTests
             SupportPhase = DotNetSupportPhase.Active,
         };
 
-        // Act and Assert
-        Should.NotThrow(() => console.WriteRuntimeNearingEndOfSupportWarning(environment, upgrade, 90));
+        foreach (var daysRemaining in new[] { 90, 1, 0, -1, -90 })
+        {
+            // Act and Assert
+            Should.NotThrow(() => console.WriteRuntimeNearingEndOfSupportWarning(environment, upgrade, daysRemaining));
+        }
     }
 
     [Fact]

--- a/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
@@ -86,7 +86,7 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
                  <AnalysisMode>All</AnalysisMode>
                  <ArtifactsPath>{artifactsPath}</ArtifactsPath>
                  <EnableNETAnalyzers>true</EnableNETAnalyzers>
-                 <NoWarn>$(NoWarn);CA1307;CA1309;CA1707</NoWarn>
+                 <NoWarn>$(NoWarn);CA1307;CA1309;CA1707;CA1819</NoWarn>
                  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
                  <UseArtifactsOutput>{useArtifactsOutput}</UseArtifactsOutput>
                </PropertyGroup>

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -133,14 +133,14 @@ internal sealed class Project : IDisposable
     {
         var testClass =
             $$"""
-              using System.Collections.Generic;
+              using System;
               using Xunit;
               
               namespace MyProject.Tests;
               
               public static class UnitTests
               {
-                  public static List<string> Items { get; } = new List<string>(); // IDE0028
+                  public static string[] Items { get; } = Array.Empty<string>(); // IDE0301
                   public static bool IsTrue() => string.Equals(bool.TrueString, "true"); // CA1307
 
                   [Fact]
@@ -293,7 +293,7 @@ internal sealed class Project : IDisposable
                  <EnableNETAnalyzers>true</EnableNETAnalyzers>
                  <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
                  <GenerateDocumentationFile>true</GenerateDocumentationFile>
-                 <NoWarn>$(NoWarn);{noWarn ?? "CA1002;CS419;CS1570;CS1573;CS1574;CS1584;CS1591"}</NoWarn>
+                 <NoWarn>$(NoWarn);{noWarn ?? "CA1002;CA1819;CS419;CS1570;CS1573;CS1574;CS1584;CS1591"}</NoWarn>
                  <TreatWarningsAsErrors>{treatWarningsAsErrors.ToString().ToLowerInvariant()}</TreatWarningsAsErrors>
                </PropertyGroup>
              </Project>


### PR DESCRIPTION
- Use array instead of `List<T>` to resolve weird compiler error with .NET 9 for a .NET 7 project seen in #154.
- Do not print a negative number of days to when a .NET release is no longer supported.
