### PR TITLE
Fix release generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Create release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           DRAFT: ${{ inputs.publish != true }}
           VERSION: ${{ steps.get-version.outputs.version }}
         with:
@@ -49,29 +50,27 @@ jobs:
             const tag_name = `v${version}`;
             const name = tag_name;
 
+            const { data: notes } = await github.rest.repos.generateReleaseNotes({
+              owner,
+              repo,
+              tag_name,
+              target_commitish: process.env.DEFAULT_BRANCH,
+            });
+
+            const body = notes.body
+              .split('\n')
+              .filter((line) => !line.includes(' @costellobot '))
+              .filter((line) => !line.includes(' @dependabot '))
+              .filter((line) => !line.includes(' @github-actions '))
+              .join('\n');
+
             const { data: release } = await github.rest.repos.createRelease({
               owner,
               repo,
               tag_name,
               name,
-              draft: true,
-              generate_release_notes: true,
-              prerelease: true,
-            });
-
-            const release_id = release.id;
-            const body = release.body
-              .split('\n')
-              .filter((line) => !line.includes(' @costellobot '))
-              .filter((line) => !line.includes(' @dependabot '))
-              .join('\n');
-
-            const { data: updated } = await github.rest.repos.updateRelease({
-              owner,
-              repo,
-              release_id,
-              draft,
               body,
+              draft,
             });
 
-            core.notice(`Created release ${updated.name}: ${updated.html_url}`);
+            core.notice(`Created release ${release.name}: ${release.html_url}`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
               name,
               body,
               draft,
+              prerelease: true,
             });
 
             core.notice(`Created release ${release.name}: ${release.html_url}`);


### PR DESCRIPTION
Fix the update losing the tag by generating the release notes before creation.

<!--

Summarise the changes this Pull Request makes.

Please include a reference to a GitHub issue if appropriate.

-->
