### PR TITLE
Revert update to System.Text.Json

### DIFF
--- a/.github/update-dotnet-sdk.json
+++ b/.github/update-dotnet-sdk.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/martincostello/github-automation/main/.github/update-dotnet-sdk-schema.json"
+  "$schema": "https://raw.githubusercontent.com/martincostello/github-automation/main/.github/update-dotnet-sdk-schema.json",
+  "exclude-nuget-packages": "System.Text.Json"
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Spectre.Console.Testing" Version="0.48.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Management.Automation" Version="7.4.1" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.9" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />


### PR DESCRIPTION
- Downgrade System.Text.Json back to 6.0.0.
- Prevent update-dotnet-sdk from updating System.Text.Json.
