### PR TITLE
Use embedded symbols

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
     <Company>https://github.com/martincostello/dotnet-bumper</Company>
     <ContinuousIntegrationBuild Condition=" '$(CI)' != '' ">true</ContinuousIntegrationBuild>
     <Copyright>Martin Costello (c) $([System.DateTime]::Now.ToString(yyyy))</Copyright>
-    <DebugType>portable</DebugType>
+    <DebugType>embedded</DebugType>
     <Deterministic Condition=" '$(IsTestProject)' == '' ">true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>


### PR DESCRIPTION
Use embedded symbols to get stack traces in exceptions with line numbers.
