### PR TITLE
Enable --warnings-as-errors

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -161,7 +161,7 @@ jobs:
       env:
         DOTNET_BUMPER_CONFIG: ${{ steps.generate-config.outputs.dotnet-bumper-config }}
         DOTNET_BUMPER_UPGRADE_TYPE: ${{ matrix.upgrade-type }}
-        DOTNET_BUMPER_WARNINGS_AS_ERRORS: ${{ matrix.warnings-as-errors || 'true' }}
+        DOTNET_BUMPER_WARNINGS_AS_ERRORS: ${{ format('{0}', matrix.warnings-as-errors) }}
       run: |
         $bumperArgs = @(
           ".",

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -79,21 +79,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        repo:
-          # - adventofcode HACK Disabled due to https://github.com/dotnet/sdk/issues/39909
-          - alexa-london-travel
-          - alexa-london-travel-site
-          - api
-          - apple-fitness-workout-mapper
-          - costellobot
-          - dependabot-helper
-          - dotnet-bumper
-          - project-euler
-          - website
-        upgrade-type:
-          - LTS
-          - Latest
-          - Preview
+        repo: [ alexa-london-travel, alexa-london-travel-site, api, apple-fitness-workout-mapper, costellobot, dependabot-helper, dotnet-bumper, project-euler, website ]
+        upgrade-type: [ LTS, Latest, Preview ]
         include:
           - repo: dotnet-bumper
             upgrade-type: Preview

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,6 +82,9 @@ jobs:
         repo: [ alexa-london-travel, alexa-london-travel-site, api, apple-fitness-workout-mapper, costellobot, dependabot-helper, dotnet-bumper, project-euler, website ]
         upgrade-type: [ LTS, Latest, Preview ]
         include:
+          - repo: alexa-london-travel-site
+            upgrade-type: Preview
+            warnings-as-errors: false
           - repo: dotnet-bumper
             upgrade-type: Preview
             warnings-as-errors: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -94,6 +94,10 @@ jobs:
           - LTS
           - Latest
           - Preview
+        include:
+          - repo: dotnet-bumper
+            upgrade-type: Preview
+            warnings-as-errors: false
 
     steps:
 
@@ -157,6 +161,7 @@ jobs:
       env:
         DOTNET_BUMPER_CONFIG: ${{ steps.generate-config.outputs.dotnet-bumper-config }}
         DOTNET_BUMPER_UPGRADE_TYPE: ${{ matrix.upgrade-type }}
+        DOTNET_BUMPER_WARNINGS_AS_ERRORS: ${{ matrix.warnings-as-errors || 'true' }}
       run: |
         $bumperArgs = @(
           ".",
@@ -166,6 +171,9 @@ jobs:
           "--upgrade-type",
           ${env:DOTNET_BUMPER_UPGRADE_TYPE}
         )
+        if (${env:DOTNET_BUMPER_WARNINGS_AS_ERRORS} -eq "true") {
+          $bumperArgs += "--warnings-as-errors"
+        }
         if (-Not [string]::IsNullOrEmpty(${env:DOTNET_BUMPER_CONFIG})) {
           $bumperArgs += "--configuration-file"
           $bumperArgs += ${env:DOTNET_BUMPER_CONFIG}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -165,6 +165,9 @@ jobs:
           $bumperArgs += "--configuration-file"
           $bumperArgs += ${env:DOTNET_BUMPER_CONFIG}
         }
+        if (${env:RUNNER_DEBUG} -eq "1") {
+          $bumperArgs += "--verbose"
+        }
         dotnet bumper $bumperArgs
 
     - name: Show git diff

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -158,7 +158,7 @@ jobs:
           "--upgrade-type",
           ${env:DOTNET_BUMPER_UPGRADE_TYPE}
         )
-        if (${env:DOTNET_BUMPER_WARNINGS_AS_ERRORS} -eq "true") {
+        if (${env:DOTNET_BUMPER_WARNINGS_AS_ERRORS} -ne "false") {
           $bumperArgs += "--warnings-as-errors"
         }
         if (-Not [string]::IsNullOrEmpty(${env:DOTNET_BUMPER_CONFIG})) {

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -146,6 +146,8 @@ internal sealed partial class DotNetTestPostProcessor(
                 environmentVariables["DirectoryBuildPropsPath"] = propertiesOverrides.Path;
             }
 
+            var verbosity = Logger.IsEnabled(LogLevel.Debug) ? "detailed" : "quiet";
+
             DotNetResult result;
 
             try
@@ -153,7 +155,7 @@ internal sealed partial class DotNetTestPostProcessor(
                 // See https://learn.microsoft.com/dotnet/core/tools/dotnet-test
                 result = await dotnet.RunWithLoggerAsync(
                     project,
-                    ["test", "--nologo", "--verbosity", "quiet", "--logger", BumperTestLogger.ExtensionUri, "--test-adapter-path", adapterDirectory.Path],
+                    ["test", "--nologo", "--verbosity", verbosity, "--logger", BumperTestLogger.ExtensionUri, "--test-adapter-path", adapterDirectory.Path],
                     environmentVariables,
                     cancellationToken);
             }


### PR DESCRIPTION
- Enable `--warnings-as-errors` for all integration tests, except for .NET previews for this repository itself as two tests fail for some reason (see #154).
- Specify `--verbose` if debug logging is enabled in GitHub Actions.
- Use `detailed` logging with `dotnet test` if `--verbose` is specified.
