### PR TITLE
Pass --pre-release-label to .NET Outdated

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -75,6 +75,7 @@ jobs:
   test:
     needs: [ package ]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -75,7 +75,7 @@ jobs:
   test:
     needs: [ package ]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -130,7 +130,7 @@ internal sealed partial class PackageVersionUpgrader(
 
             // Requires .NET Outdated v4.6.1+.
             // See https://github.com/dotnet-outdated/dotnet-outdated/pull/467.
-            if (sdkVersion.IsPrerelease && sdkVersion.ReleaseLabels.Count() > 1)
+            if (sdkVersion.IsPrerelease && sdkVersion.ReleaseLabels.Count() > 2)
             {
                 var label = string.Join('.', sdkVersion.ReleaseLabels.Take(2));
 

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using MartinCostello.DotNetBumper.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using NuGet.Versioning;
 using Spectre.Console;
 
 namespace MartinCostello.DotNetBumper.Upgraders;
@@ -50,7 +51,7 @@ internal sealed partial class PackageVersionUpgrader(
 
                 context.Status = StatusMessage($"Update NuGet packages for {name}...");
 
-                result = result.Max(await TryUpgradePackagesAsync(project, cancellationToken));
+                result = result.Max(await TryUpgradePackagesAsync(project, upgrade.SdkVersion, cancellationToken));
             }
         }
 
@@ -108,7 +109,10 @@ internal sealed partial class PackageVersionUpgrader(
         }
     }
 
-    private async Task<ProcessingResult> TryUpgradePackagesAsync(string directory, CancellationToken cancellationToken)
+    private async Task<ProcessingResult> TryUpgradePackagesAsync(
+        string directory,
+        NuGetVersion sdkVersion,
+        CancellationToken cancellationToken)
     {
         using var tempFile = new TemporaryFile();
 
@@ -123,6 +127,16 @@ internal sealed partial class PackageVersionUpgrader(
         if (Options.UpgradeType is UpgradeType.Preview)
         {
             arguments.Add("--pre-release:Always");
+
+            // Requires .NET Outdated v4.6.1+.
+            // See https://github.com/dotnet-outdated/dotnet-outdated/pull/467.
+            if (sdkVersion.IsPrerelease && sdkVersion.ReleaseLabels.Count() > 1)
+            {
+                var label = string.Join('.', sdkVersion.ReleaseLabels.Take(2));
+
+                arguments.Add("--pre-release-label");
+                arguments.Add(label);
+            }
         }
 
         var configuration = await configurationProvider.GetAsync(cancellationToken);

--- a/tests/DotNetBumper.Tests/BumperConfigurationLoaderTests.cs
+++ b/tests/DotNetBumper.Tests/BumperConfigurationLoaderTests.cs
@@ -68,8 +68,8 @@ public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData("custom.json", @"{""noWarn"":[""warning-42""]}")]
-    [InlineData("CUSTOM.JSON", @"{""noWarn"":[""warning-42""]}")]
+    [InlineData("custom.json", /*lang=json,strict*/ @"{""noWarn"":[""warning-42""]}")]
+    [InlineData("CUSTOM.JSON", /*lang=json,strict*/ @"{""noWarn"":[""warning-42""]}")]
     [InlineData("custom.yml", "noWarn:\n- warning-42")]
     [InlineData("custom.YML", "noWarn:\n- warning-42")]
     public async Task LoadAsync_When_Custom_Configuration(string fileName, string content)
@@ -182,6 +182,7 @@ public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
     {
         var path = Path.Combine(fixture.Project.DirectoryName, ".dotnet-bumper.json");
 
+        /*lang=json*/
         string content =
             """
             {

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -10,6 +10,19 @@ namespace MartinCostello.DotNetBumper;
 
 public class EndToEndTests(ITestOutputHelper outputHelper)
 {
+    [Fact]
+    public static async Task Application_Validates_Project_Exists()
+    {
+        // Arrange
+        string projectPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        // Act
+        int actual = await Program.Main([projectPath]);
+
+        // Assert
+        actual.ShouldBe(1);
+    }
+
     public static TheoryData<BumperTestCase> TestCases()
     {
         var testCases = new TheoryData<BumperTestCase>
@@ -42,7 +55,9 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
+#pragma warning disable xUnit1044 // Avoid using TheoryData type arguments that are not serializable
     [MemberData(nameof(TestCases))]
+#pragma warning restore xUnit1044 // Avoid using TheoryData type arguments that are not serializable
     public async Task Application_Upgrades_Project(BumperTestCase testCase)
     {
         // Arrange
@@ -333,19 +348,6 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
 
         logContent.ShouldNotBeNullOrWhiteSpace();
         logContent.ShouldContain("Error");
-    }
-
-    [Fact]
-    public async Task Application_Validates_Project_Exists()
-    {
-        // Arrange
-        string projectPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-        // Act
-        int actual = await Program.Main([projectPath]);
-
-        // Assert
-        actual.ShouldBe(1);
     }
 
     [Fact]

--- a/tests/DotNetBumper.Tests/JsonExtensionsTests.cs
+++ b/tests/DotNetBumper.Tests/JsonExtensionsTests.cs
@@ -46,7 +46,7 @@ public static class JsonExtensionsTests
     private static string WriteJsonToFile(bool writeBom)
     {
         var bom = writeBom ? Encoding.UTF8.Preamble : [];
-        var json = "{\"foo\":\"bar\"}"u8;
+        var json = /*lang=json,strict*/ "{\"foo\":\"bar\"}"u8;
 
         string path = Path.GetTempFileName();
 


### PR DESCRIPTION
Consume change from dotnet-outdated/dotnet-outdated#467 and pass the `--pre-release-label` argument to .NET Outdated to pin any NuGet package updates to the same release as associated with the .NET SDK for a preview.

As this only applies to previews, I think it's fine to assume/require the user has .NET Outdated v4.6.1+ installed.
