### PR TITLE
Fix package upgrades when MSBuild SDKs used

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -80,10 +80,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # alexa-london-travel removed due to https://github.com/microsoft/testfx/issues/2733
-        repo: [ alexa-london-travel-site, api, apple-fitness-workout-mapper, costellobot, dependabot-helper, dotnet-bumper, project-euler, website ]
+        repo: [ alexa-london-travel, alexa-london-travel-site, api, apple-fitness-workout-mapper, costellobot, dependabot-helper, dotnet-bumper, project-euler, website ]
         upgrade-type: [ LTS, Latest, Preview ]
         include:
+          # alexa-london-travel tests disabled due to https://github.com/microsoft/testfx/issues/2733
+          - repo: alexa-london-travel
+            test: false
+            upgrade-type: LTS
+            warnings-as-errors: false
+          - repo: alexa-london-travel
+            test: false
+            upgrade-type: Latest
+            warnings-as-errors: false
+          - repo: alexa-london-travel
+            test: false
+            upgrade-type: Preview
+            warnings-as-errors: false
           - repo: alexa-london-travel-site
             upgrade-type: Preview
             warnings-as-errors: false
@@ -152,6 +164,7 @@ jobs:
       shell: pwsh
       env:
         DOTNET_BUMPER_CONFIG: ${{ steps.generate-config.outputs.dotnet-bumper-config }}
+        DOTNET_BUMPER_TEST: ${{ format('{0}', matrix.test) }}
         DOTNET_BUMPER_UPGRADE_TYPE: ${{ matrix.upgrade-type }}
         DOTNET_BUMPER_WARNINGS_AS_ERRORS: ${{ format('{0}', matrix.warnings-as-errors) }}
       run: |
@@ -159,10 +172,12 @@ jobs:
           ".",
           "--log-format",
           "GitHubActions",
-          "--test",
           "--upgrade-type",
           ${env:DOTNET_BUMPER_UPGRADE_TYPE}
         )
+        if (${env:DOTNET_BUMPER_TEST} -ne "false") {
+          $bumperArgs += "--test"
+        }
         if (${env:DOTNET_BUMPER_WARNINGS_AS_ERRORS} -ne "false") {
           $bumperArgs += "--warnings-as-errors"
         }
@@ -185,7 +200,7 @@ jobs:
     needs: [ package, test ]
     if: ${{ always() }}
     env:
-      TESTS_SUCCESS: ${{ !contains(needs.*.result, 'failure') }} 
+      TESTS_SUCCESS: ${{ !contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     steps:
     - run: |

--- a/src/DotNetBumper.Core/DotNetProcess.cs
+++ b/src/DotNetBumper.Core/DotNetProcess.cs
@@ -18,6 +18,23 @@ public sealed partial class DotNetProcess(ILogger<DotNetProcess> logger)
     /// </summary>
     /// <param name="workingDirectory">The working directory for the process.</param>
     /// <param name="arguments">The arguments to the command.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+    /// <returns>
+    /// A <see cref="Task{DotNetResult}"/> representing the asynchronous operation to run the command.
+    /// </returns>
+    public async Task<DotNetResult> RunAsync(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        return await RunAsync(workingDirectory, null, arguments, null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs the specified dotnet command.
+    /// </summary>
+    /// <param name="workingDirectory">The working directory for the process.</param>
+    /// <param name="arguments">The arguments to the command.</param>
     /// <param name="environmentVariables">The environment variables to set for the process, if any.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
     /// <returns>

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -250,7 +250,6 @@ internal sealed partial class DotNetTestPostProcessor(
             var getProperty = await dotnet.RunAsync(
                 Options.ProjectPath,
                 ["msbuild", projectPath, $"-getProperty:{propertyName}"],
-                null,
                 cancellationToken);
 
             if (getProperty.Success)

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -327,6 +327,7 @@ internal sealed partial class PackageVersionUpgrader(
                     (!sdk.TryGetPropertyValue(AllowPrereleaseProperty, out var allowPrerelease) ||
                      allowPrerelease?.GetValueKind() is not JsonValueKind.True))
                 {
+                    sdk.Remove(AllowPrereleaseProperty);
                     sdk.Add(new(AllowPrereleaseProperty, JsonValue.Create(true)));
                     edited = true;
                 }

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -42,9 +42,14 @@ internal sealed partial class PackageVersionUpgrader(
 
             context.Status = StatusMessage($"Updating {name}...");
 
-            using (TryHideGlobalJson(project))
-            using (TryDotNetToolManifest(project))
+            using (await TryPatchGlobalJsonAsync(project, cancellationToken))
             {
+                if (HasDotNetToolManifest(project))
+                {
+                    context.Status = StatusMessage($"Restore .NET tools for {name}...");
+                    await TryRestoreToolsAsync(project, cancellationToken);
+                }
+
                 context.Status = StatusMessage($"Restore NuGet packages for {name}...");
 
                 await TryRestoreNuGetPackagesAsync(project, cancellationToken);
@@ -63,38 +68,43 @@ internal sealed partial class PackageVersionUpgrader(
         return result;
     }
 
-    private static HiddenFile? TryHideGlobalJson(string path)
+    private static async Task<PatchedGlobalJsonFile?> TryPatchGlobalJsonAsync(string path, CancellationToken cancellationToken)
     {
         var globalJson = FileHelpers.FindFileInProject(path, WellKnownFileNames.GlobalJson);
 
         if (globalJson != null)
         {
-            return new HiddenFile(globalJson);
+            var patched = new PatchedGlobalJsonFile(globalJson);
+
+            try
+            {
+                await patched.TryRemoveSdkVersionAsync(cancellationToken);
+                return patched;
+            }
+            catch (Exception)
+            {
+                patched.Dispose();
+                throw;
+            }
         }
 
         return null;
     }
 
-    private static HiddenFile? TryDotNetToolManifest(string path)
-    {
-        var toolManifest = FileHelpers.FindFileInProject(path, Path.Join(".config", WellKnownFileNames.ToolsManifest));
-
-        if (toolManifest != null)
-        {
-            return new HiddenFile(toolManifest);
-        }
-
-        return null;
-    }
+    private static bool HasDotNetToolManifest(string path)
+        => FileHelpers.FindFileInProject(path, Path.Join(".config", WellKnownFileNames.ToolsManifest)) is not null;
 
     private List<string> FindProjects()
         => ProjectHelpers.FindProjects(Options.ProjectPath, SearchOption.AllDirectories);
+
+    private string GetVerbosity()
+        => Logger.IsEnabled(LogLevel.Debug) ? "detailed" : "quiet";
 
     private async Task TryRestoreNuGetPackagesAsync(string directory, CancellationToken cancellationToken)
     {
         var result = await dotnet.RunWithLoggerAsync(
             directory,
-            ["restore", "--verbosity", "quiet"],
+            ["restore", "--verbosity", GetVerbosity()],
             cancellationToken);
 
         logContext.Add(result);
@@ -106,6 +116,25 @@ internal sealed partial class PackageVersionUpgrader(
         else
         {
             Log.UnableToRestorePackages(logger, directory);
+        }
+    }
+
+    private async Task TryRestoreToolsAsync(string directory, CancellationToken cancellationToken)
+    {
+        var result = await dotnet.RunAsync(
+            directory,
+            ["tool", "restore", "--verbosity", GetVerbosity()],
+            cancellationToken);
+
+        logContext.Add(result);
+
+        if (result.Success)
+        {
+            Log.RestoredTools(logger, directory);
+        }
+        else
+        {
+            Log.UnableToRestoreTools(logger, directory);
         }
     }
 
@@ -235,21 +264,58 @@ internal sealed partial class PackageVersionUpgrader(
             Level = LogLevel.Warning,
             Message = "Unable to restore NuGet packages for {Directory}.")]
         public static partial void UnableToRestorePackages(ILogger logger, string directory);
+
+        [LoggerMessage(
+            EventId = 5,
+            Level = LogLevel.Debug,
+            Message = "Restored .NET tools for {Directory}.")]
+        public static partial void RestoredTools(ILogger logger, string directory);
+
+        [LoggerMessage(
+            EventId = 6,
+            Level = LogLevel.Warning,
+            Message = "Unable to restore .NET tools for {Directory}.")]
+        public static partial void UnableToRestoreTools(ILogger logger, string directory);
     }
 
-    private sealed class HiddenFile : IDisposable
+    private sealed class PatchedGlobalJsonFile : IDisposable
     {
-        private readonly string _original;
-        private readonly string _temporary;
+        private readonly string _filePath;
+        private readonly string _backupPath;
 
-        public HiddenFile(string source)
+        public PatchedGlobalJsonFile(string source)
         {
-            _original = source;
-            _temporary = $"{source}.{Guid.NewGuid().ToString()[0..8]}.tmp";
-            File.Move(_original, _temporary);
+            _filePath = source;
+            _backupPath = $"{source}.{Guid.NewGuid().ToString()[0..8]}.tmp";
+            File.Copy(_filePath, _backupPath, overwrite: true);
         }
 
         public void Dispose()
-            => File.Move(_temporary, _original, overwrite: true);
+            => File.Move(_backupPath, _filePath, overwrite: true);
+
+        public async Task TryRemoveSdkVersionAsync(CancellationToken cancellationToken)
+        {
+            if (!JsonHelpers.TryLoadObject(_filePath, out var globalJson))
+            {
+                return;
+            }
+
+            // Drop the version from the SDK property in the global.json file
+            // but keep any other content, such as versions for MSBuild SDKs.
+            if (globalJson.TryGetPropertyValue("sdk", out var property) &&
+                property?.GetValueKind() is JsonValueKind.Object)
+            {
+                var sdk = property.AsObject();
+
+                const string VersionProperty = "version";
+
+                if (sdk.TryGetPropertyValue(VersionProperty, out var version) &&
+                    version?.GetValueKind() is JsonValueKind.String)
+                {
+                    sdk.Remove(VersionProperty);
+                    await globalJson.SaveAsync(_filePath, cancellationToken);
+                }
+            }
+        }
     }
 }

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -114,7 +114,7 @@ internal sealed class Project : IDisposable
               "isRoot": true,
               "tools": {
                 "dotnet-outdated-tool": {
-                  "version": "4.6.0",
+                  "version": "4.6.1",
                   "commands": [
                     "dotnet-outdated"
                   ]


### PR DESCRIPTION
- Fix NuGet package upgrades not working when the `global.json` file contains MSBuild SDK versions.
- Restore .NET global tools during upgrades.
- Add convenience overload for running .NET commands with no custom environment variables.
- Bump dotnet-outdated-tool used in test projects to 4.6.1.
- Use `detailed` verbosity for restore if `--verbose` is specified.
- Re-enable the integration tests for alexa-london-travel, but with `--test` disabled.
