### PR TITLE
Reduce analysis scopes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.2.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
+    <PackageVersion Include="Microsoft.Build" Version="17.9.5" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />

--- a/src/DotNetBumper.Core/DotNetBumper.Core.csproj
+++ b/src/DotNetBumper.Core/DotNetBumper.Core.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Ignore" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
+    <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using MartinCostello.DotNetBumper.Logging;
+using Microsoft.Build.Construction;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Versioning;
@@ -39,6 +40,8 @@ internal sealed partial class DotNetCodeUpgrader(
         CancellationToken cancellationToken)
     {
         Log.UpgradingDotNetCode(Logger);
+
+        fileNames = TryReduceAnalysis(fileNames);
 
         var diagnostics = new Dictionary<string, int>();
         var result = ProcessingResult.None;
@@ -237,6 +240,40 @@ internal sealed partial class DotNetCodeUpgrader(
         return fixes;
     }
 
+    private IReadOnlyList<string> TryReduceAnalysis(IReadOnlyList<string> fileNames)
+    {
+        var solutionFiles = fileNames.Where((p) => Path.GetExtension(p) is ".sln").ToList();
+        var projectFiles = fileNames.Where((p) => Path.GetExtension(p) is not ".sln").ToList();
+
+        if (solutionFiles.Count is 0 || projectFiles.Count is 0)
+        {
+            return fileNames;
+        }
+
+        foreach (var solutionFile in solutionFiles)
+        {
+            try
+            {
+                var solution = SolutionFile.Parse(solutionFile);
+                var projects = solution.ProjectsInOrder.Where((p) => p.ProjectType != SolutionProjectType.SolutionFolder);
+
+                foreach (var project in projects)
+                {
+                    if (project.AbsolutePath is { Length: > 0 } projectFile)
+                    {
+                        projectFiles.Remove(projectFile);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.FailedToDetermineSolutionProjects(Logger, solutionFile, ex);
+            }
+        }
+
+        return [.. solutionFiles, .. projectFiles];
+    }
+
     private record struct DiagnosticFix(string FilePath, string DiagnosticId, int LineNumber);
 
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
@@ -259,5 +296,11 @@ internal sealed partial class DotNetCodeUpgrader(
             Level = LogLevel.Debug,
             Message = "Fixed diagnostic {DiagnosticId} in {FileName}:{LineNumber}.")]
         public static partial void FixedDiagnostic(ILogger logger, string diagnosticId, string fileName, int lineNumber);
+
+        [LoggerMessage(
+            EventId = 4,
+            Level = LogLevel.Debug,
+            Message = "Failed to determine projects included in the solution file {SolutionFile}.")]
+        public static partial void FailedToDetermineSolutionProjects(ILogger logger, string solutionFile, Exception exception);
     }
 }

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -36,7 +36,7 @@ internal sealed partial class PackageVersionUpgrader(
 
         context.Status = StatusMessage("Finding projects...");
 
-        foreach (string project in FindProjects())
+        foreach (string project in ProjectHelpers.FindProjects(Options.ProjectPath))
         {
             var name = RelativeName(project);
 
@@ -70,9 +70,6 @@ internal sealed partial class PackageVersionUpgrader(
 
     private static bool HasDotNetToolManifest(string path)
         => FileHelpers.FindFileInProject(path, Path.Join(".config", WellKnownFileNames.ToolsManifest)) is not null;
-
-    private List<string> FindProjects()
-        => ProjectHelpers.FindProjects(Options.ProjectPath, SearchOption.AllDirectories);
 
     private string GetVerbosity()
         => Logger.IsEnabled(LogLevel.Debug) ? "detailed" : "quiet";


### PR DESCRIPTION
Reduce the scope of analysis for `dotnet format`, `dotnet outdated` and `dotnet test` by deduping projects that are part of a solution.
