### PR TITLE
Refactor MSBuild resolution

### DIFF
--- a/src/DotNetBumper.Core/MSBuildHelper.cs
+++ b/src/DotNetBumper.Core/MSBuildHelper.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper;
+
+internal static class MSBuildHelper
+{
+    //// Adapted from https://github.com/microsoft/MSBuildLocator/blob/66d20e511bc5d4a022584218caeded9936ab534f/src/MSBuildLocator/MSBuildLocator.cs
+
+    public static void TryAddSdkProperties(IDictionary<string, string?> environment, string sdkVersion)
+    {
+        var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+
+        if (string.IsNullOrEmpty(dotnetRoot))
+        {
+            dotnetRoot = Path.Combine(
+                Environment.GetFolderPath(
+                    OperatingSystem.IsWindows() ?
+                    Environment.SpecialFolder.ProgramFiles :
+                    Environment.SpecialFolder.CommonApplicationData),
+                "dotnet");
+        }
+
+        var dotNetSdkPath = Path.Combine(dotnetRoot, "sdk", sdkVersion);
+
+        if (!Directory.Exists(dotNetSdkPath))
+        {
+            return;
+        }
+
+        environment["MSBUILD_EXE_PATH"] = Path.Combine(dotNetSdkPath, "MSBuild.dll");
+        environment["MSBuildExtensionsPath"] = dotNetSdkPath;
+        environment["MSBuildSDKsPath"] = Path.Combine(dotNetSdkPath, "Sdks");
+    }
+}

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -53,7 +53,7 @@ internal sealed partial class DotNetTestPostProcessor(
         }
         else
         {
-            var result = await RunTestsAsync(projects, context, cancellationToken);
+            var result = await RunTestsAsync(upgrade.SdkVersion.ToString(), projects, context, cancellationToken);
 
             logContext.Add(result);
 
@@ -117,6 +117,7 @@ internal sealed partial class DotNetTestPostProcessor(
     }
 
     private async Task<DotNetResult> RunTestsAsync(
+        string sdkVersion,
         List<string> projects,
         StatusContext context,
         CancellationToken cancellationToken)
@@ -130,7 +131,7 @@ internal sealed partial class DotNetTestPostProcessor(
             string name = ProjectHelpers.RelativeName(Options.ProjectPath, project);
             context.Status = StatusMessage($"Running tests for {name}...");
 
-            var result = await RunTestsAsync(project, configuration, cancellationToken);
+            var result = await RunTestsAsync(sdkVersion, project, configuration, cancellationToken);
 
             if (!result.Success)
             {
@@ -160,6 +161,7 @@ internal sealed partial class DotNetTestPostProcessor(
     }
 
     private async Task<DotNetResult> RunTestsAsync(
+        string sdkVersion,
         string project,
         BumperConfiguration configuration,
         CancellationToken cancellationToken)
@@ -171,6 +173,8 @@ internal sealed partial class DotNetTestPostProcessor(
         {
             [BumperTestLogger.LoggerDirectoryPathVariableName] = logsDirectory.Path,
         };
+
+        MSBuildHelper.TryAddSdkProperties(environmentVariables, sdkVersion);
 
         TemporaryFile? propertiesOverrides = null;
 

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -53,7 +53,7 @@ internal sealed partial class DotNetTestPostProcessor(
         }
         else
         {
-            var result = await RunTestsAsync(upgrade.SdkVersion.ToString(), projects, context, cancellationToken);
+            var result = await RunTestsAsync(projects, context, cancellationToken);
 
             logContext.Add(result);
 
@@ -117,7 +117,6 @@ internal sealed partial class DotNetTestPostProcessor(
     }
 
     private async Task<DotNetResult> RunTestsAsync(
-        string sdkVersion,
         List<string> projects,
         StatusContext context,
         CancellationToken cancellationToken)
@@ -131,7 +130,7 @@ internal sealed partial class DotNetTestPostProcessor(
             string name = ProjectHelpers.RelativeName(Options.ProjectPath, project);
             context.Status = StatusMessage($"Running tests for {name}...");
 
-            var result = await RunTestsAsync(sdkVersion, project, configuration, cancellationToken);
+            var result = await RunTestsAsync(project, configuration, cancellationToken);
 
             if (!result.Success)
             {
@@ -161,7 +160,6 @@ internal sealed partial class DotNetTestPostProcessor(
     }
 
     private async Task<DotNetResult> RunTestsAsync(
-        string sdkVersion,
         string project,
         BumperConfiguration configuration,
         CancellationToken cancellationToken)
@@ -173,8 +171,6 @@ internal sealed partial class DotNetTestPostProcessor(
         {
             [BumperTestLogger.LoggerDirectoryPathVariableName] = logsDirectory.Path,
         };
-
-        MSBuildHelper.TryAddSdkProperties(environmentVariables, sdkVersion);
 
         TemporaryFile? propertiesOverrides = null;
 

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -52,7 +52,6 @@ internal sealed partial class DotNetCodeUpgrader(
             context.Status = StatusMessage($"Updating .NET code for {relativePath}...");
 
             (var fileResult, var fixes) = await ApplyFixesAsync(
-                upgrade.Channel,
                 fileName,
                 upgrade.SdkVersion,
                 cancellationToken);
@@ -78,47 +77,7 @@ internal sealed partial class DotNetCodeUpgrader(
         return result;
     }
 
-    private static Dictionary<string, string?> GetFormatEnvironment(Version channel, string sdkVersion)
-    {
-        var environment = new Dictionary<string, string?>()
-        {
-            ["NoWarn"] = "CA1515", // HACK Ignore CA1515 from .NET 9 as it seems to just break things
-        };
-
-        if (channel.Major > 7)
-        {
-            // HACK dotnet format seems to have issues resolving where the .NET SDK is installed
-            // with .NET 8. If MSBuildSDKsPath is set, it needs to be overridden otherwise it may
-            // point to an SDK version that is lower that the one we are upgrading to.
-            const string MSBuildSDKsPath = "MSBuildSDKsPath";
-
-            var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
-
-            if (string.IsNullOrEmpty(dotnetRoot))
-            {
-                dotnetRoot = Path.Combine(
-                    Environment.GetFolderPath(
-                        OperatingSystem.IsWindows() ?
-                        Environment.SpecialFolder.ProgramFiles :
-                        Environment.SpecialFolder.CommonApplicationData),
-                    "dotnet");
-            }
-
-            var msbuildSdksPath = Path.Combine(
-                dotnetRoot,
-                "sdk",
-                sdkVersion,
-                "Sdks");
-
-            // This has to be specifically set because DotNetProcess will otherwise unset it for other reasons
-            environment[MSBuildSDKsPath] = msbuildSdksPath;
-        }
-
-        return environment;
-    }
-
     private async Task<(ProcessingResult Result, Dictionary<string, int> Fixes)> ApplyFixesAsync(
-        Version channel,
         string projectOrSolution,
         NuGetVersion sdkVersion,
         CancellationToken cancellationToken)
@@ -138,7 +97,12 @@ internal sealed partial class DotNetCodeUpgrader(
             "--verbosity", Logger.GetMSBuildVerbosity(),
         ];
 
-        var environmentVariables = GetFormatEnvironment(channel, globalJson?.SdkVersion ?? sdkVersion.ToString());
+        var environmentVariables = new Dictionary<string, string?>()
+        {
+            ["NoWarn"] = "CA1515", // HACK Ignore CA1515 from .NET 9 as it seems to just break things
+        };
+
+        MSBuildHelper.TryAddSdkProperties(environmentVariables, globalJson?.SdkVersion ?? sdkVersion.ToString());
 
         var formatResult = await dotnet.RunAsync(
             workingDirectory,

--- a/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
@@ -8,6 +8,8 @@ namespace MartinCostello.DotNetBumper.PostProcessors;
 
 public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
 {
+    private static TimeSpan Timeout { get; } = TimeSpan.FromMinutes(1);
+
     public static TheoryData<string> Channels()
     {
 #pragma warning disable IDE0028 // See https://github.com/dotnet/roslyn/issues/72668
@@ -31,8 +33,10 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
 
         var target = CreateTarget(fixture);
 
+        using var cts = new CancellationTokenSource(Timeout);
+
         // Act
-        var actual = await target.PostProcessAsync(upgrade, CancellationToken.None);
+        var actual = await target.PostProcessAsync(upgrade, cts.Token);
 
         // Assert
         actual.ShouldBe(ProcessingResult.Success);
@@ -51,8 +55,10 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
 
         var target = CreateTarget(fixture);
 
+        using var cts = new CancellationTokenSource(Timeout);
+
         // Act
-        var actual = await target.PostProcessAsync(upgrade, CancellationToken.None);
+        var actual = await target.PostProcessAsync(upgrade, cts.Token);
 
         // Assert
         actual.ShouldBe(ProcessingResult.Success);
@@ -97,8 +103,10 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
 
         var target = CreateTarget(fixture);
 
+        using var cts = new CancellationTokenSource(Timeout);
+
         // Act
-        var actual = await target.PostProcessAsync(upgrade, CancellationToken.None);
+        var actual = await target.PostProcessAsync(upgrade, cts.Token);
 
         // Assert
         actual.ShouldBe(ProcessingResult.Success);
@@ -142,7 +150,9 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
             Microsoft.Extensions.Options.Options.Create(new UpgradeOptions() { DotNetChannel = channel }),
             outputHelper.ToLogger<DotNetUpgradeFinder>());
 
-        var upgrade = await finder.GetUpgradeAsync(CancellationToken.None);
+        using var cts = new CancellationTokenSource(Timeout);
+
+        var upgrade = await finder.GetUpgradeAsync(cts.Token);
         upgrade.ShouldNotBeNull();
 
         return upgrade;

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -5,6 +5,8 @@ namespace MartinCostello.DotNetBumper.Upgraders;
 
 public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 {
+    private static TimeSpan Timeout { get; } = TimeSpan.FromMinutes(1);
+
     public static TheoryData<string> Channels()
     {
 #pragma warning disable IDE0028 // See https://github.com/dotnet/roslyn/issues/72668
@@ -54,15 +56,17 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 
         var target = CreateTarget(fixture);
 
+        using var cts = new CancellationTokenSource(Timeout);
+
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, cts.Token);
 
         // Assert
         actual.ShouldBe(ProcessingResult.Success);
         fixture.LogContext.Changelog.ShouldContain("Fix IDE0057 warning");
 
         // Act
-        actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actual = await target.UpgradeAsync(upgrade, cts.Token);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -109,15 +113,17 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 
         var target = CreateTarget(fixture);
 
+        using var cts = new CancellationTokenSource(Timeout);
+
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, cts.Token);
 
         // Assert
         actual.ShouldBe(ProcessingResult.Success);
         fixture.LogContext.Changelog.ShouldContain("Fix IDE0057 warnings");
 
         // Act
-        actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actual = await target.UpgradeAsync(upgrade, cts.Token);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -160,8 +166,10 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 
         var target = CreateTarget(fixture);
 
+        using var cts = new CancellationTokenSource(Timeout);
+
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, cts.Token);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -204,8 +212,10 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 
         var target = CreateTarget(fixture);
 
+        using var cts = new CancellationTokenSource(Timeout);
+
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, cts.Token);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -272,7 +282,9 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
             Microsoft.Extensions.Options.Options.Create(new UpgradeOptions() { DotNetChannel = channel }),
             outputHelper.ToLogger<DotNetUpgradeFinder>());
 
-        var upgrade = await finder.GetUpgradeAsync(CancellationToken.None);
+        using var cts = new CancellationTokenSource(Timeout);
+
+        var upgrade = await finder.GetUpgradeAsync(cts.Token);
         upgrade.ShouldNotBeNull();
 
         return upgrade;

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -5,7 +5,7 @@ namespace MartinCostello.DotNetBumper.Upgraders;
 
 public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 {
-    private static TimeSpan Timeout { get; } = TimeSpan.FromMinutes(1);
+    private static TimeSpan Timeout { get; } = TimeSpan.FromMinutes(2);
 
     public static TheoryData<string> Channels()
     {


### PR DESCRIPTION
- Copy the approach from `Microsoft.Build.Locator` to set environment variables for use when invoking the .NET CLI.
- Do not wait indefinitely for upgrade actions to complete in tests.
