### PR TITLE
Add --timeout option

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -185,6 +185,8 @@ jobs:
           ".",
           "--log-format",
           "GitHubActions",
+          "--timeout",
+          "00:25:00",
           "--upgrade-type",
           ${env:DOTNET_BUMPER_UPGRADE_TYPE}
         )

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Options:
   -t|--upgrade-type <TYPE>         The type of upgrade to perform.
                                    Allowed values are: Lts, Latest, Preview.
   -test|--test                     Test the upgrade by running dotnet test on completion.
+  -timeout|--timeout <TIMESPAN>    The optional period to timeout the upgrade after.
   -e|--warnings-as-errors          Treat any warnings encountered during the upgrade as errors.
 ```
 

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -381,7 +381,7 @@ internal sealed partial class DotNetTestPostProcessor(
         [LoggerMessage(
             EventId = 1,
             Level = LogLevel.Debug,
-            Message = "Failed to evaluate MSBuild the value of the {PropertyName} MSBuild property from {ProjectFile}.")]
+            Message = "Failed to evaluate the value of the {PropertyName} MSBuild property from {ProjectFile}.")]
         public static partial void FailedToEvaluateProperty(ILogger logger, string propertyName, string projectFile, Exception exception);
     }
 }

--- a/src/DotNetBumper/Bumper.cs
+++ b/src/DotNetBumper/Bumper.cs
@@ -81,7 +81,7 @@ internal partial class Bumper(ProjectUpgrader upgrader)
         using var serviceProvider = new ServiceCollection()
             .AddSingleton<IModelAccessor>(app)
             .AddSingleton<IPostConfigureOptions<UpgradeOptions>, UpgradePostConfigureOptions>()
-            .AddProjectUpgrader(configuration, console, (builder) => configureLogging(builder).SetMinimumLevel(logLevel))
+            .AddProjectUpgrader(configuration, console, (builder) => ConfigureLogging(configureLogging(builder), logLevel))
             .BuildServiceProvider();
 
         app.Conventions
@@ -98,6 +98,10 @@ internal partial class Bumper(ProjectUpgrader upgrader)
             console.WriteWarningLine(ex.Message);
             return 1;
         }
+
+        static ILoggingBuilder ConfigureLogging(ILoggingBuilder builder, LogLevel logLevel)
+            => builder.SetMinimumLevel(logLevel)
+                      .AddFilter("Microsoft.Extensions.Http.DefaultHttpClientFactory", (p) => p > LogLevel.Debug);
     }
 
     public static string GetVersion() => ProjectUpgrader.Version;

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -427,6 +427,23 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task Application_Returns_Three_If_Timeout()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        // Act
+        int actual = await Bumper.RunAsync(
+            fixture.Console,
+            [fixture.Project.DirectoryName, "--verbose", "--timeout", "00:00:00"],
+            (builder) => builder.AddXUnit(fixture),
+            CancellationToken.None);
+
+        // Assert
+        actual.ShouldBe(3);
+    }
+
+    [Fact]
     public async Task Application_Validates_Project_Is_Specified()
     {
         // Arrange

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -55,9 +55,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-#pragma warning disable xUnit1044 // Avoid using TheoryData type arguments that are not serializable
     [MemberData(nameof(TestCases))]
-#pragma warning restore xUnit1044 // Avoid using TheoryData type arguments that are not serializable
     public async Task Application_Upgrades_Project(BumperTestCase testCase)
     {
         // Arrange


### PR DESCRIPTION
- Add an option to timeout the upgrade using `--timeout`.
- Timeout any integration tests after 25 minutes to print any logs reached up to that point, rather than a hard terminate from GitHub Actions at 30 minutes.
- Implement `IXunitSerializable` on `BumperTestCase` to resolve `xUnit1044` warning and improve developer experience in Visual Studio.
- Fix typo in log message.
- Filter out debug logs from `Microsoft.Extensions.Http.DefaultHttpClientFactory`.
- Refactor method to split execution from the loop of executions.