### PR TITLE
Change DOTNET_ROLL_FORWARD behaviour

### DIFF
--- a/src/DotNetBumper.Core/DotNetProcess.cs
+++ b/src/DotNetBumper.Core/DotNetProcess.cs
@@ -96,7 +96,7 @@ public sealed partial class DotNetProcess(ILogger<DotNetProcess> logger)
         {
             EnvironmentVariables =
             {
-                ["DOTNET_ROLL_FORWARD"] = "Major",
+                ["DOTNET_ROLL_FORWARD"] = "Minor",
                 ["MSBuildSDKsPath"] = null,
                 [BumperBuildLogger.LoggerFilePathVariableName] = customLoggerFileName,
             },

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -156,7 +156,10 @@ internal sealed partial class PackageVersionUpgrader(
             arguments.Add(package);
         }
 
-        var environmentVariables = new Dictionary<string, string?>(1);
+        var environmentVariables = new Dictionary<string, string?>(2)
+        {
+            ["DOTNET_ROLL_FORWARD"] = "Major",
+        };
 
         if (configuration.NoWarn.Count > 0)
         {


### PR DESCRIPTION
Use `DOTNET_ROLL_FORWARD=Minor` by default and only `Major` for `dotnet outdated`.
