### PR TITLE
Fix InvalidOperationException for .NET 9

### DIFF
--- a/tests/DotNetBumper.Tests/DotNetBumper.Tests.csproj
+++ b/tests/DotNetBumper.Tests/DotNetBumper.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -10,19 +10,22 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 #pragma warning disable IDE0028 // See https://github.com/dotnet/roslyn/issues/72668
         return new()
         {
-#if !NET9_0_OR_GREATER // HACK For some yet-unknown reason, this test fails when .NET Bumper is built with .NET 9
             "7.0",
-#endif
             //// "8.0", See https://github.com/dotnet/sdk/issues/39742
             //// "9.0", See https://github.com/dotnet/sdk/issues/39909 and https://github.com/dotnet/sdk/issues/40174
         };
 #pragma warning restore IDE0028
     }
 
-    [Theory]
+    [SkippableTheory]
     [MemberData(nameof(Channels))]
     public async Task UpgradeAsync_Applies_Code_Fix(string channel)
     {
+#if NET9_0_OR_GREATER
+        // HACK For some yet-unknown reason, this test fails with .NET 9
+        Skip.If(true, "Fails with .NET 9.");
+#endif
+
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
 
@@ -65,10 +68,15 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
         actual.ShouldBe(ProcessingResult.None);
     }
 
-    [Theory]
+    [SkippableTheory]
     [MemberData(nameof(Channels))]
     public async Task UpgradeAsync_Applies_Code_Fixes(string channel)
     {
+#if NET9_0_OR_GREATER
+        // HACK For some yet-unknown reason, this test fails with .NET 9
+        Skip.If(true, "Fails with .NET 9.");
+#endif
+
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
 
@@ -115,10 +123,15 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
         actual.ShouldBe(ProcessingResult.None);
     }
 
-    [Theory]
+    [SkippableTheory]
     [MemberData(nameof(Channels))]
     public async Task UpgradeAsync_Honors_User_Project_Settings(string channel)
     {
+#if NET9_0_OR_GREATER
+        // HACK For some yet-unknown reason, this test fails with .NET 9
+        Skip.If(true, "Fails with .NET 9.");
+#endif
+
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
 
@@ -154,10 +167,15 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
         actual.ShouldBe(ProcessingResult.None);
     }
 
-    [Theory]
+    [SkippableTheory]
     [MemberData(nameof(Channels))]
     public async Task UpgradeAsync_Does_Not_Fix_Information_Diagnostics(string channel)
     {
+#if NET9_0_OR_GREATER
+        // HACK For some yet-unknown reason, this test fails with .NET 9
+        Skip.If(true, "Fails with .NET 9.");
+#endif
+
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
 


### PR DESCRIPTION
Fix `InvalidOperationException ` when running the tests with .NET 9 by skipping rather than removing the test cases.
