### PR TITLE
Fix global.json patching

### DIFF
--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -138,7 +138,7 @@ internal sealed partial class DotNetCodeUpgrader(
             "--verbosity", Logger.GetMSBuildVerbosity(),
         ];
 
-        var environmentVariables = GetFormatEnvironment(channel, sdkVersion.ToString());
+        var environmentVariables = GetFormatEnvironment(channel, globalJson?.SdkVersion ?? sdkVersion.ToString());
 
         var formatResult = await dotnet.RunAsync(
             workingDirectory,


### PR DESCRIPTION
- Do not downgrade the SDK when patching it to run a dotnet tool. Otherwise it can cause `dotnet restore` to fail and `dotnet format` to hang.
- If stdout/stderr is not redirected (e.g. for debugging), then just immediately return an empty StringBuilder.
