### PR TITLE
Reduce use of template literals in tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0" />
+    <PackageVersion Include="MSBuild.ProjectCreation" Version="12.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="NuGet.Versioning" Version="6.9.1" />
     <PackageVersion Include="ReportGenerator" Version="5.2.4" />

--- a/tests/DotNetBumper.Tests/DotNetBumper.Tests.csproj
+++ b/tests/DotNetBumper.Tests/DotNetBumper.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSBuild.ProjectCreation" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Shouldly" />

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -588,10 +588,13 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
         var xml = await fixture.Project.GetFileAsync(fileName);
         var project = XDocument.Parse(xml);
 
+        project.Root.ShouldNotBeNull();
+        var ns = project.Root.GetDefaultNamespace();
+
         var tfm = project
-            .Root?
-            .Element("PropertyGroup")?
-            .Element("TargetFramework")?
+            .Root
+            .Element(ns + "PropertyGroup")?
+            .Element(ns + "TargetFramework")?
             .Value;
 
         if (tfm is not null)
@@ -600,9 +603,9 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
         }
 
         return project
-            .Root?
-            .Element("PropertyGroup")?
-            .Element("TargetFrameworks")?
+            .Root
+            .Element(ns + "PropertyGroup")?
+            .Element(ns + "TargetFrameworks")?
             .Value;
     }
 

--- a/tests/DotNetBumper.Tests/JsonNodeExtensions.cs
+++ b/tests/DotNetBumper.Tests/JsonNodeExtensions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization.Metadata;
+
+namespace System.Text.Json.Nodes;
+
+internal static class JsonNodeExtensions
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
+        WriteIndented = true,
+    };
+
+    public static string PrettyPrint(this JsonNode node)
+        => node.ToJsonString(SerializerOptions);
+}

--- a/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
@@ -89,9 +89,9 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
         var properties = ProjectCreator.Create()
             .Property("AnalysisMode", "All")
             .Property("ArtifactsPath", artifactsPath)
-            .Property("EnableNETAnalyzers", "true")
+            .Property("EnableNETAnalyzers", true)
             .Property("NoWarn", "$(NoWarn);CA1307;CA1309;CA1707;CA1819")
-            .Property("TreatWarningsAsErrors", "true")
+            .Property("TreatWarningsAsErrors", true)
             .Property("UseArtifactsOutput", useArtifactsOutput);
 
         await fixture.Project.AddFileAsync("Directory.Build.props", properties.Xml);

--- a/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using MartinCostello.DotNetBumper.Upgraders;
+using Microsoft.Build.Utilities.ProjectCreation;
 using NSubstitute;
 
 namespace MartinCostello.DotNetBumper.PostProcessors;
@@ -85,21 +86,15 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
 
         fixture.UserConfiguration.NoWarn = ["CA1002", "CA1515"];
 
-        string properties =
-            $"""
-             <Project>
-               <PropertyGroup>
-                 <AnalysisMode>All</AnalysisMode>
-                 <ArtifactsPath>{artifactsPath}</ArtifactsPath>
-                 <EnableNETAnalyzers>true</EnableNETAnalyzers>
-                 <NoWarn>$(NoWarn);CA1307;CA1309;CA1707;CA1819</NoWarn>
-                 <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-                 <UseArtifactsOutput>{useArtifactsOutput}</UseArtifactsOutput>
-               </PropertyGroup>
-             </Project>
-             """;
+        var properties = ProjectCreator.Create()
+            .Property("AnalysisMode", "All")
+            .Property("ArtifactsPath", artifactsPath)
+            .Property("EnableNETAnalyzers", "true")
+            .Property("NoWarn", "$(NoWarn);CA1307;CA1309;CA1707;CA1819")
+            .Property("TreatWarningsAsErrors", "true")
+            .Property("UseArtifactsOutput", useArtifactsOutput);
 
-        await fixture.Project.AddFileAsync("Directory.Build.props", properties);
+        await fixture.Project.AddFileAsync("Directory.Build.props", properties.Xml);
 
         var target = CreateTarget(fixture);
 

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -96,6 +96,7 @@ internal sealed class Project : IDisposable
     {
         // HACK dotnet outdated does not determine whether the project is an SDK-style
         // project correctly when the XML namespace is present in the project file.
+        // See https://github.com/dotnet-outdated/dotnet-outdated/pull/541.
         var xml = project.Xml.Replace(" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"", string.Empty, StringComparison.Ordinal);
         return await AddFileAsync(path, xml);
     }

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -94,7 +94,7 @@ internal sealed class Project : IDisposable
 
     public async Task<string> AddProjectAsync(string path, ProjectCreator project)
     {
-        // HACK dotet outdated does not determine whether the project is an SDK-style
+        // HACK dotnet outdated does not determine whether the project is an SDK-style
         // project correctly when the XML namespace is present in the project file.
         var xml = project.Xml.Replace(" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"", string.Empty, StringComparison.Ordinal);
         return await AddFileAsync(path, xml);

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Xml.Linq;
+using System.Text.Json.Nodes;
+using Microsoft.Build.Utilities.ProjectCreation;
 
 namespace MartinCostello.DotNetBumper;
 
@@ -10,12 +11,6 @@ internal sealed class Project : IDisposable
     private readonly TemporaryDirectory _directory = new();
 
     public string DirectoryName => _directory.Path;
-
-    public async Task<string> AddFileAsync(string path, XDocument content)
-    {
-        var xml = content.ToString(SaveOptions.DisableFormatting);
-        return await AddFileAsync(path, xml);
-    }
 
     public async Task<string> AddFileAsync(string path, string content, Encoding? encoding = null)
     {
@@ -42,13 +37,12 @@ internal sealed class Project : IDisposable
 
     public async Task AddGitIgnoreAsync(string? gitignore = null)
     {
-        gitignore ??=
-            """
-            .idea
-            .vs
-            bin
-            obj
-            """;
+        gitignore ??= new StringBuilder()
+            .AppendLine(".idea")
+            .AppendLine(".vs")
+            .AppendLine("bin")
+            .AppendLine("obj")
+            .ToString();
 
         await AddFileAsync(".gitignore", gitignore);
     }
@@ -81,8 +75,8 @@ internal sealed class Project : IDisposable
         packageReferences ??= new Dictionary<string, string>()
         {
             ["Microsoft.NET.Test.Sdk"] = "17.9.0",
-            ["xunit"] = "2.7.0",
-            ["xunit.runner.visualstudio"] = "2.5.7",
+            ["xunit"] = "2.7.1",
+            ["xunit.runner.visualstudio"] = "2.5.8",
         };
 
         return await AddProjectAsync(path, targetFrameworks, packageReferences, projectReferences);
@@ -94,9 +88,12 @@ internal sealed class Project : IDisposable
         ICollection<KeyValuePair<string, string>>? packageReferences = default,
         ICollection<string>? projectReferences = default)
     {
-        var project = CreateProjectXml(targetFrameworks, packageReferences, projectReferences);
-        return await AddFileAsync(path, project);
+        var project = CreateProject(targetFrameworks, packageReferences, projectReferences);
+        return await AddProjectAsync(path, project);
     }
+
+    public async Task<string> AddProjectAsync(string path, ProjectCreator project)
+        => await AddFileAsync(path, project.Xml);
 
     public async Task<string> AddSolutionAsync(string path)
     {
@@ -106,24 +103,24 @@ internal sealed class Project : IDisposable
 
     public async Task<string> AddToolManifestAsync(string path = ".config/dotnet-tools.json")
     {
-        // lang=json,strict
-        var manifest =
-            """
+        var manifest = new JsonObject()
+        {
+            ["version"] = 1,
+            ["isRoot"] = true,
+            ["tools"] = new JsonObject()
             {
-              "version": 1,
-              "isRoot": true,
-              "tools": {
-                "dotnet-outdated-tool": {
-                  "version": "4.6.1",
-                  "commands": [
-                    "dotnet-outdated"
-                  ]
-                }
-              }
-            }
-            """;
+                ["dotnet-outdated-tool"] = new JsonObject()
+                {
+                    ["version"] = "4.6.1",
+                    ["commands"] = new JsonArray()
+                    {
+                        "dotnet-outdated",
+                    },
+                },
+            },
+        };
 
-        return await AddFileAsync(path, manifest);
+        return await AddFileAsync(path, manifest.PrettyPrint());
     }
 
     public async Task<string> AddUnitTestsAsync(
@@ -193,22 +190,21 @@ internal sealed class Project : IDisposable
 
     public async Task<string> AddVisualStudioConfigurationAsync(string channel = "6.0", string path = ".vsconfig")
     {
-        var configuration =
-            $$"""
-              {
-                "version": "1.0",
-                "components": [
-                  "Component.GitHub.VisualStudio",
-                  "Microsoft.NetCore.Component.Runtime.{{channel}}",
-                  "Microsoft.NetCore.Component.SDK",
-                  "Microsoft.VisualStudio.Component.CoreEditor",
-                  "Microsoft.VisualStudio.Component.Git",
-                  "Microsoft.VisualStudio.Workload.CoreEditor"
-                ]
-              }
-              """;
+        var configuration = new JsonObject()
+        {
+            ["version"] = "1.0",
+            ["components"] = new JsonArray()
+            {
+                "Component.GitHub.VisualStudio",
+                $"Microsoft.NetCore.Component.Runtime.{channel}",
+                "Microsoft.NetCore.Component.SDK",
+                "Microsoft.VisualStudio.Component.CoreEditor",
+                "Microsoft.VisualStudio.Component.Git",
+                "Microsoft.VisualStudio.Workload.CoreEditor",
+            },
+        };
 
-        return await AddFileAsync(path, configuration);
+        return await AddFileAsync(path, configuration.PrettyPrint());
     }
 
     public async Task<string> AddPowerShellBuildScriptAsync(Version channel, string path = "build.ps1")
@@ -285,78 +281,63 @@ internal sealed class Project : IDisposable
         bool treatWarningsAsErrors = false)
     {
 #pragma warning disable CA1308
-        string properties =
-            $"""
-             <Project>
-               <PropertyGroup>
-                 <AnalysisMode>All</AnalysisMode>
-                 <EnableNETAnalyzers>true</EnableNETAnalyzers>
-                 <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-                 <GenerateDocumentationFile>true</GenerateDocumentationFile>
-                 <NoWarn>$(NoWarn);{noWarn ?? "CA1002;CA1819;CS419;CS1570;CS1573;CS1574;CS1584;CS1591"}</NoWarn>
-                 <TreatWarningsAsErrors>{treatWarningsAsErrors.ToString().ToLowerInvariant()}</TreatWarningsAsErrors>
-               </PropertyGroup>
-             </Project>
-             """;
+        var builder = ProjectCreator.Create()
+            .Property("AnalysisMode", "All")
+            .Property("EnableNETAnalyzers", "true")
+            .Property("EnforceCodeStyleInBuild", "true")
+            .Property("GenerateDocumentationFile", "true")
+            .Property("NoWarn", $"$(NoWarn);{noWarn ?? "CA1002;CA1819;CS419;CS1570;CS1573;CS1574;CS1584;CS1591"}")
+            .Property("TreatWarningsAsErrors", treatWarningsAsErrors.ToString().ToLowerInvariant());
 #pragma warning restore CA1308
 
-        await AddFileAsync("Directory.Build.props", properties);
+        await AddFileAsync("Directory.Build.props", builder.Xml);
     }
 
     public void Dispose() => _directory.Dispose();
 
     private static string CreateGlobalJson(string sdkVersion)
     {
-        return $$"""
-                 {
-                   "sdk": {
-                     "version": "{{sdkVersion}}"
-                   }
-                 }
-                 """;
+        var globalJson = new JsonObject()
+        {
+            ["sdk"] = new JsonObject()
+            {
+                ["version"] = sdkVersion,
+            },
+        };
+
+        return globalJson.PrettyPrint();
     }
 
-    private static XDocument CreateProjectXml(
+    private static ProjectCreator CreateProject(
         IList<string> targetFrameworks,
         ICollection<KeyValuePair<string, string>>? packageReferences,
         ICollection<string>? projectReferences)
     {
-        string tfms = targetFrameworks.Count == 1
-            ? $"<TargetFramework>{targetFrameworks[0]}</TargetFramework>"
-            : $"<TargetFrameworks>{string.Join(";", targetFrameworks)}</TargetFrameworks>";
+        var project = ProjectCreator.Create(sdk: "Microsoft.NET.Sdk");
 
-        string xml = $"""
-                      <Project Sdk="Microsoft.NET.Sdk">
-                        <PropertyGroup>
-                          {tfms}
-                        </PropertyGroup>
-                      </Project>
-                      """
-        ;
-
-        var project = XDocument.Parse(xml);
+        if (targetFrameworks.Count is 1)
+        {
+            project.Property("TargetFramework", targetFrameworks[0]);
+        }
+        else if (targetFrameworks.Count > 0)
+        {
+            project.Property("TargetFrameworks", string.Join(";", targetFrameworks));
+        }
 
         if (packageReferences?.Count > 0)
         {
-            project.Root!.Add(
-                new XElement(
-                    "ItemGroup",
-                    packageReferences.Select((p) =>
-                        new XElement(
-                            "PackageReference",
-                            new XAttribute("Include", p.Key),
-                            new XAttribute("Version", p.Value)))));
+            foreach (var package in packageReferences)
+            {
+                project.ItemPackageReference(package.Key, package.Value);
+            }
         }
 
         if (projectReferences?.Count > 0)
         {
-            project.Root!.Add(
-                new XElement(
-                    "ItemGroup",
-                    projectReferences.Select((p) =>
-                        new XElement(
-                            "ProjectReference",
-                            new XAttribute("Include", p)))));
+            foreach (var reference in projectReferences)
+            {
+                project.ItemProjectReference(reference);
+            }
         }
 
         return project;

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -280,15 +280,13 @@ internal sealed class Project : IDisposable
         string? noWarn = null,
         bool treatWarningsAsErrors = false)
     {
-#pragma warning disable CA1308
         var builder = ProjectCreator.Create()
             .Property("AnalysisMode", "All")
-            .Property("EnableNETAnalyzers", "true")
-            .Property("EnforceCodeStyleInBuild", "true")
-            .Property("GenerateDocumentationFile", "true")
+            .Property("EnableNETAnalyzers", true)
+            .Property("EnforceCodeStyleInBuild", true)
+            .Property("GenerateDocumentationFile", true)
             .Property("NoWarn", $"$(NoWarn);{noWarn ?? "CA1002;CA1819;CS419;CS1570;CS1573;CS1574;CS1584;CS1591"}")
-            .Property("TreatWarningsAsErrors", treatWarningsAsErrors.ToString().ToLowerInvariant());
-#pragma warning restore CA1308
+            .Property("TreatWarningsAsErrors", treatWarningsAsErrors);
 
         await AddFileAsync("Directory.Build.props", builder.Xml);
     }
@@ -319,7 +317,7 @@ internal sealed class Project : IDisposable
         {
             project.Property("TargetFramework", targetFrameworks[0]);
         }
-        else if (targetFrameworks.Count > 0)
+        else if (targetFrameworks.Count > 1)
         {
             project.Property("TargetFrameworks", string.Join(";", targetFrameworks));
         }

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -311,7 +311,7 @@ internal sealed class Project : IDisposable
         ICollection<KeyValuePair<string, string>>? packageReferences,
         ICollection<string>? projectReferences)
     {
-        var project = ProjectCreator.Create(sdk: "Microsoft.NET.Sdk");
+        var project = ProjectCreator.Create(sdk: ProjectCreatorConstants.SdkCsprojDefaultSdk);
 
         if (targetFrameworks.Count is 1)
         {

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -93,7 +93,12 @@ internal sealed class Project : IDisposable
     }
 
     public async Task<string> AddProjectAsync(string path, ProjectCreator project)
-        => await AddFileAsync(path, project.Xml);
+    {
+        // HACK dotet outdated does not determine whether the project is an SDK-style
+        // project correctly when the XML namespace is present in the project file.
+        var xml = project.Xml.Replace(" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"", string.Empty, StringComparison.Ordinal);
+        return await AddFileAsync(path, xml);
+    }
 
     public async Task<string> AddSolutionAsync(string path)
     {

--- a/tests/DotNetBumper.Tests/ProjectCreatorExtensions.cs
+++ b/tests/DotNetBumper.Tests/ProjectCreatorExtensions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Utilities.ProjectCreation;
+
+internal static class ProjectCreatorExtensions
+{
+#pragma warning disable CA1308
+    public static ProjectCreator Property(this ProjectCreator project, string name, bool value)
+        => project.Property(name, value.ToString().ToLowerInvariant());
+#pragma warning restore CA1308
+}

--- a/tests/DotNetBumper.Tests/Upgraders/AwsLambdaToolsUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/AwsLambdaToolsUpgraderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Spectre.Console.Testing;
 
 namespace MartinCostello.DotNetBumper.Upgraders;
@@ -13,25 +14,24 @@ public class AwsLambdaToolsUpgraderTests(ITestOutputHelper outputHelper)
     public async Task UpgradeAsync_Upgrades_Properties(string channel)
     {
         // Arrange
-        // lang=json,strict
-        string fileContents =
-            """
-            {
-              "profile": "alexa-london-travel",
-              "region": "eu-west-1",
-              "configuration": "Release",
-              "framework": "net6.0",
-              "function-architecture": "arm64",
-              "function-handler": "MyApplication",
-              "function-memory-size": 192,
-              "function-runtime": "dotnet6",
-              "function-timeout": 10
-            }
-            """;
+        var configuration = new JsonObject()
+        {
+            ["profile"] = "alexa-london-travel",
+            ["region"] = "eu-west-1",
+            ["configuration"] = "Release",
+            ["framework"] = "net6.0",
+            ["function-architecture"] = "arm64",
+            ["function-handler"] = "MyApplication",
+            ["function-memory-size"] = 192,
+            ["function-runtime"] = "dotnet6",
+            ["function-timeout"] = 10,
+        };
 
         using var fixture = new UpgraderFixture(outputHelper);
 
-        string lambdaDefaultsFile = await fixture.Project.AddFileAsync("aws-lambda-tools-defaults.json", fileContents);
+        var lambdaDefaultsFile = await fixture.Project.AddFileAsync(
+            "aws-lambda-tools-defaults.json",
+            configuration.PrettyPrint());
 
         var upgrade = new UpgradeInfo()
         {
@@ -83,25 +83,26 @@ public class AwsLambdaToolsUpgraderTests(ITestOutputHelper outputHelper)
         DotNetSupportPhase supportPhase)
     {
         // Arrange
-        // lang=json,strict
-        string fileContents =
-            """
-            {
-              "profile": "alexa-london-travel",
-              "region": "eu-west-1",
-              "configuration": "Release",
-              "framework": "net6.0",
-              "function-architecture": "arm64",
-              "function-handler": "MyApplication",
-              "function-memory-size": 192,
-              "function-runtime": "dotnet6",
-              "function-timeout": 10
-            }
-            """;
+        var configuration = new JsonObject()
+        {
+            ["profile"] = "alexa-london-travel",
+            ["region"] = "eu-west-1",
+            ["configuration"] = "Release",
+            ["framework"] = "net6.0",
+            ["function-architecture"] = "arm64",
+            ["function-handler"] = "MyApplication",
+            ["function-memory-size"] = 192,
+            ["function-runtime"] = "dotnet6",
+            ["function-timeout"] = 10,
+        };
+
+        var fileContents = configuration.PrettyPrint();
 
         using var fixture = new UpgraderFixture(outputHelper);
 
-        string lambdaDefaultsFile = await fixture.Project.AddFileAsync("aws-lambda-tools-defaults.json", fileContents);
+        var lambdaDefaultsFile = await fixture.Project.AddFileAsync(
+            "aws-lambda-tools-defaults.json",
+            fileContents);
 
         var upgrade = new UpgradeInfo()
         {

--- a/tests/DotNetBumper.Tests/Upgraders/RuntimeIdentifierUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/RuntimeIdentifierUpgraderTests.cs
@@ -56,7 +56,7 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
         string expectedValue)
     {
         // Arrange
-        var builder = ProjectCreator.Create(sdk: "Microsoft.NET.Sdk")
+        var builder = ProjectCreator.Create(sdk: ProjectCreatorConstants.SdkCsprojDefaultSdk)
             .Property(propertyName, propertyValue);
 
         using var fixture = new UpgraderFixture(outputHelper);
@@ -300,7 +300,7 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
     public async Task UpgradeAsync_Does_Not_Change_DotNet_7_Runtime_Identifiers()
     {
         // Arrange
-        var builder = ProjectCreator.Create(sdk: "Microsoft.NET.Sdk")
+        var builder = ProjectCreator.Create(sdk: ProjectCreatorConstants.SdkCsprojDefaultSdk)
             .Property("RuntimeIdentifier", "win10-x64");
 
         var fileContents = builder.Xml;

--- a/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
@@ -59,7 +59,7 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
         string expectedValue)
     {
         // Arrange
-        var builder = ProjectCreator.Create(sdk: "Microsoft.NET.Sdk")
+        var builder = ProjectCreator.Create(sdk: ProjectCreatorConstants.SdkCsprojDefaultSdk)
             .Property(propertyName, propertyValue);
 
         using var fixture = new UpgraderFixture(outputHelper);


### PR DESCRIPTION
- Use MSBuildProjectCreator to create project test fixtures.
- Use JsonNode APIs to remove JSON literals where appropriate.

Resolves #196.
