### PR TITLE
Pass --no-restore to dotnet format

### DIFF
--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -92,6 +92,7 @@ internal sealed partial class DotNetCodeUpgrader(
         [
             "format",
             "analyzers",
+            "--no-restore",
             "--report", tempDirectory.Path,
             "--severity", "warn",
             "--verbosity", Logger.GetMSBuildVerbosity(),


### PR DESCRIPTION
Specify `--no-restore` when running dotnet format as NuGet packages should have already been restored prior to it running.
