### PR TITLE
Standardise test timeout

### DIFF
--- a/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
@@ -9,7 +9,7 @@ namespace MartinCostello.DotNetBumper.PostProcessors;
 
 public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
 {
-    private static TimeSpan Timeout { get; } = TimeSpan.FromMinutes(1);
+    private static TimeSpan Timeout { get; } = TimeSpan.FromMinutes(3);
 
     public static TheoryData<string> Channels()
     {

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -5,7 +5,7 @@ namespace MartinCostello.DotNetBumper.Upgraders;
 
 public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 {
-    private static TimeSpan Timeout { get; } = TimeSpan.FromMinutes(2);
+    private static TimeSpan Timeout { get; } = TimeSpan.FromMinutes(3);
 
     public static TheoryData<string> Channels()
     {


### PR DESCRIPTION
To make CI less flaky, use 3 minute timeout for all tests with an explicit timeout.
