### PR TITLE
Update container base image

### DIFF
--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -70,6 +70,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<IUpgrader, AwsLambdaToolsUpgrader>();
         services.AddSingleton<IUpgrader, AwsSamTemplateUpgrader>();
+        services.AddSingleton<IUpgrader, ContainerBaseImageUpgrader>();
         services.AddSingleton<IUpgrader, DockerfileUpgrader>();
         services.AddSingleton<IUpgrader, DotNetCodeUpgrader>();
         services.AddSingleton<IUpgrader, GlobalJsonUpgrader>();

--- a/src/DotNetBumper.Core/Upgraders/ContainerBaseImageUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/ContainerBaseImageUpgrader.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+using MartinCostello.DotNetBumper.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+internal sealed partial class ContainerBaseImageUpgrader(
+    IAnsiConsole console,
+    IEnvironment environment,
+    BumperLogContext logContext,
+    IOptions<UpgradeOptions> options,
+    ILogger<ContainerBaseImageUpgrader> logger) : XmlFileUpgrader(console, environment, options, logger)
+{
+    protected override string Action => "Upgrading container base images";
+
+    protected override string InitialStatus => "Update RIDs";
+
+    protected override IReadOnlyList<string> Patterns { get; } =
+    [
+        WellKnownFileNames.DirectoryBuildProps,
+        WellKnownFileNames.CSharpProjects,
+        WellKnownFileNames.FSharpProjects,
+        WellKnownFileNames.VisualBasicProjects,
+    ];
+
+    protected override async Task<ProcessingResult> UpgradeCoreAsync(
+        UpgradeInfo upgrade,
+        IReadOnlyList<string> fileNames,
+        StatusContext context,
+        CancellationToken cancellationToken)
+    {
+        Log.UpgradingContainerBaseImage(Logger);
+
+        var result = ProcessingResult.None;
+
+        foreach (var filePath in fileNames)
+        {
+            var name = RelativeName(filePath);
+
+            context.Status = StatusMessage($"Parsing {name}...");
+
+            (var project, var metadata) = await LoadProjectAsync(filePath, cancellationToken);
+
+            if (project is null || project.Root is null)
+            {
+                result = result.Max(ProcessingResult.Warning);
+                continue;
+            }
+
+            bool edited = false;
+
+            foreach (var property in ProjectHelpers.EnumerateProperties(project.Root))
+            {
+                if (TryUpgradeContainerBaseImage(property, upgrade.Channel))
+                {
+                    edited = true;
+                }
+            }
+
+            if (edited)
+            {
+                context.Status = StatusMessage($"Updating {name}...");
+
+                await UpdateProjectAsync(filePath, project, metadata, cancellationToken);
+
+                result = result.Max(ProcessingResult.Success);
+            }
+        }
+
+        if (result is ProcessingResult.Success)
+        {
+            logContext.Changelog.Add("Update container base images");
+        }
+
+        return result;
+    }
+
+    private static bool TryUpgradeContainerBaseImage(XElement property, Version channel)
+    {
+        if (property.Name == (property.GetDefaultNamespace() + "ContainerBaseImage") &&
+            DockerfileUpgrader.TryUpdateImage(property.Value, channel, out var updated))
+        {
+            property.SetValue(updated);
+            return true;
+        }
+
+        return false;
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Debug,
+            Message = "Upgrading container base image.")]
+        public static partial void UpgradingContainerBaseImage(ILogger logger);
+    }
+}

--- a/src/DotNetBumper.Core/Upgraders/ContainerBaseImageUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/ContainerBaseImageUpgrader.cs
@@ -18,7 +18,7 @@ internal sealed partial class ContainerBaseImageUpgrader(
 {
     protected override string Action => "Upgrading container base images";
 
-    protected override string InitialStatus => "Update RIDs";
+    protected override string InitialStatus => "Update container base images";
 
     protected override IReadOnlyList<string> Patterns { get; } =
     [

--- a/src/DotNetBumper.Core/Upgraders/DockerfileUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DockerfileUpgrader.cs
@@ -66,13 +66,10 @@ internal sealed partial class DockerfileUpgrader(
         if (edited)
         {
             updated = builder.ToString();
-
             Debug.Assert(!string.Equals(image, updated, StringComparison.Ordinal), "The container image was not updated.");
-
-            return true;
         }
 
-        return false;
+        return edited;
     }
 
     internal static bool TryUpdateImage(

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -12,6 +12,9 @@ internal sealed class Project : IDisposable
 
     public string DirectoryName => _directory.Path;
 
+    public static ProjectCreator Create(bool hasSdk = false)
+        => ProjectCreator.Create(sdk: hasSdk ? ProjectCreatorConstants.SdkCsprojDefaultSdk : null);
+
     public async Task<string> AddFileAsync(string path, string content, Encoding? encoding = null)
     {
         EnsureDirectoryTree(path);
@@ -286,7 +289,7 @@ internal sealed class Project : IDisposable
         string? noWarn = null,
         bool treatWarningsAsErrors = false)
     {
-        var builder = ProjectCreator.Create()
+        var builder = Create()
             .Property("AnalysisMode", "All")
             .Property("EnableNETAnalyzers", true)
             .Property("EnforceCodeStyleInBuild", true)
@@ -317,7 +320,7 @@ internal sealed class Project : IDisposable
         ICollection<KeyValuePair<string, string>>? packageReferences,
         ICollection<string>? projectReferences)
     {
-        var project = ProjectCreator.Create(sdk: ProjectCreatorConstants.SdkCsprojDefaultSdk);
+        var project = Create(hasSdk: true);
 
         if (targetFrameworks.Count is 1)
         {

--- a/tests/DotNetBumper.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/DotNetBumper.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using MartinCostello.DotNetBumper.PostProcessors;
+using MartinCostello.DotNetBumper.Upgraders;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console.Testing;
+
+namespace MartinCostello.DotNetBumper;
+
+public static class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public static void AddProjectUpgrader_Registers_All_Upgraders()
+    {
+        // Arrange, Act and Assert
+        AddProjectUpgraderRegistersAllImplementations<IUpgrader>();
+    }
+
+    [Fact]
+    public static void AddProjectUpgrader_Registers_All_PostProcessors()
+    {
+        // Arrange, Act and Assert
+        AddProjectUpgraderRegistersAllImplementations<IPostProcessor>();
+    }
+
+    private static void AddProjectUpgraderRegistersAllImplementations<T>()
+        where T : notnull
+    {
+        // Arrange
+        var expected = typeof(T).Assembly
+            .GetTypes()
+            .Where((p) => typeof(T).IsAssignableFrom(p))
+            .Where((p) => !p.IsAbstract)
+            .Where((p) => !p.IsInterface)
+            .ToArray();
+
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+        using var console = new TestConsole();
+
+        // Act
+        services.AddProjectUpgrader(configuration, console, (_) => { });
+
+        // Assert
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var actual = serviceProvider.GetServices<T>();
+
+        actual.ShouldNotBeNull();
+        actual.Select((p) => p.GetType())
+              .ToArray()
+              .ShouldBe(expected, ignoreOrder: true);
+    }
+}

--- a/tests/DotNetBumper.Tests/Upgraders/ContainerBaseImageUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/ContainerBaseImageUpgraderTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+public class ContainerBaseImageUpgraderTests(ITestOutputHelper outputHelper)
+{
+    [Theory]
+    [ClassData(typeof(DotNetChannelTestData))]
+    public async Task UpgradeAsync_Upgrades_Dockerfile(string channel)
+    {
+        // Arrange
+        var builder = Project
+            .Create(hasSdk: true)
+            .Property("ContainerBaseImage", "mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0-noble-chiseled-extra");
+
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string projectFile = await fixture.Project.AddFileAsync("MyProject.csproj", builder.Xml);
+
+        var upgrade = new UpgradeInfo()
+        {
+            Channel = Version.Parse(channel),
+            EndOfLife = DateOnly.MaxValue,
+            ReleaseType = DotNetReleaseType.Lts,
+            SdkVersion = new($"{channel}.100"),
+            SupportPhase = DotNetSupportPhase.Active,
+        };
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBe(ProcessingResult.Success);
+
+        var xml = await fixture.Project.GetFileAsync(projectFile);
+        var project = XDocument.Parse(xml);
+
+        project.Root.ShouldNotBeNull();
+        var ns = project.Root.GetDefaultNamespace();
+
+        var actualValue = project
+            .Root
+            .Element(ns + "PropertyGroup")?
+            .Element(ns + "ContainerBaseImage")?
+            .Value;
+
+        actualValue.ShouldBe($"mcr.microsoft.com/dotnet/nightly/runtime-deps:{channel}-noble-chiseled-extra");
+
+        // Act
+        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBe(ProcessingResult.None);
+    }
+
+    private static ContainerBaseImageUpgrader CreateTarget(UpgraderFixture fixture)
+    {
+        return new(
+            fixture.Console,
+            fixture.Environment,
+            fixture.LogContext,
+            fixture.CreateOptions(),
+            fixture.CreateLogger<ContainerBaseImageUpgrader>());
+    }
+}

--- a/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
@@ -94,7 +94,7 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
         actual.Groups["name"].Value.ShouldBe(expectedName);
     }
 
-    public static TheoryData<string, Version, DotNetSupportPhase, bool, string?> DockerImages()
+    public static TheoryData<string, string, DotNetSupportPhase, bool, string?> DockerImages()
     {
         (string Channel, DotNetSupportPhase Type)[] channels =
         [
@@ -108,83 +108,80 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
             ("10.0", DotNetSupportPhase.GoLive),
         ];
 
-        var testCases = new TheoryData<string, Version, DotNetSupportPhase, bool, string?>()
+        var testCases = new TheoryData<string, string, DotNetSupportPhase, bool, string?>()
         {
             // Invalid/unsupported images
-            { string.Empty, new(0, 0), DotNetSupportPhase.Active, false, null },
-            { " ", new(0, 0), DotNetSupportPhase.Active, false, null },
-            { "foo", new(0, 0), DotNetSupportPhase.Active, false, null },
-            { "FROM mcr.microsoft.com/vscode/devcontainers/dotnet:latest@sha256:6e5d9440418393a00b05d306bf45bbab97d4bb9771f2b5d52f5f2304e393cc2f", new(8, 0), DotNetSupportPhase.Active, false, null },
+            { string.Empty, "0.0", DotNetSupportPhase.Active, false, null },
+            { " ", "0.0", DotNetSupportPhase.Active, false, null },
+            { "foo", "0.0", DotNetSupportPhase.Active, false, null },
+            { "FROM mcr.microsoft.com/vscode/devcontainers/dotnet:latest@sha256:6e5d9440418393a00b05d306bf45bbab97d4bb9771f2b5d52f5f2304e393cc2f", "8.0", DotNetSupportPhase.Active, false, null },
         };
 
         // Already up-to-date images
         foreach ((var channel, var type) in channels)
         {
-            var version = Version.Parse(channel);
-
-            testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel}", version, type, false, null);
-            testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel}-preview", version, type, false, null);
-            testCases.Add($"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk", version, type, false, null);
-            testCases.Add($"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra", version, type, false, null);
+            testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel}", channel, type, false, null);
+            testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel}-preview", channel, type, false, null);
+            testCases.Add($"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk", channel, type, false, null);
+            testCases.Add($"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra", channel, type, false, null);
 
             // With name
-            testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel} AS build", version, type, false, null);
-            testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel} AS build-env", version, type, false, null);
-            testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel}-preview AS build", version, type, false, null);
-            testCases.Add($"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build", version, type, false, null);
-            testCases.Add($"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra AS final", version, type, false, null);
+            testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel} AS build", channel, type, false, null);
+            testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel} AS build-env", channel, type, false, null);
+            testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel}-preview AS build", channel, type, false, null);
+            testCases.Add($"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build", channel, type, false, null);
+            testCases.Add($"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra AS final", channel, type, false, null);
 
             // With platform
-            testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}", version, type, false, null);
-            testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}-preview", version, type, false, null);
-            testCases.Add($"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk", version, type, false, null);
-            testCases.Add($"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra", version, type, false, null);
+            testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}", channel, type, false, null);
+            testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}-preview", channel, type, false, null);
+            testCases.Add($"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk", channel, type, false, null);
+            testCases.Add($"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra", channel, type, false, null);
 
             // With platform and name
-            testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel} AS build", version, type, false, null);
-            testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel} AS build-env", version, type, false, null);
-            testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}-preview AS build", version, type, false, null);
-            testCases.Add($"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build", version, type, false, null);
-            testCases.Add($"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra AS final", version, type, false, null);
+            testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel} AS build", channel, type, false, null);
+            testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel} AS build-env", channel, type, false, null);
+            testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}-preview AS build", channel, type, false, null);
+            testCases.Add($"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build", channel, type, false, null);
+            testCases.Add($"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra AS final", channel, type, false, null);
         }
 
         foreach ((var channel, var type) in channels)
         {
-            var version = Version.Parse(channel);
             var suffix = type is DotNetSupportPhase.Preview ? "-preview" : string.Empty;
 
-            testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0", version, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
-            testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0-preview", version, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
-            testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra", version, type, true, $"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra");
-            testCases.Add("FROM docker.custom-domain.com/base-images/dotnet-6.0-sdk", version, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
-            testCases.Add("From docker.custom-domain.com/base-images/dotnet-6.0-sdk", version, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
-            testCases.Add("from docker.custom-domain.com/base-images/dotnet-6.0-sdk", version, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
+            testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0", channel, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
+            testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0-preview", channel, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
+            testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra", channel, type, true, $"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra");
+            testCases.Add("FROM docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
+            testCases.Add("From docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
+            testCases.Add("from docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
 
             // With name
-            testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS build", version, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
-            testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS build-env", version, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build-env");
-            testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0-preview AS build", version, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
-            testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra AS final", version, type, true, $"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra AS final");
-            testCases.Add("FROM docker.custom-domain.com/base-images/dotnet-6.0-sdk AS build", version, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build");
-            testCases.Add("From docker.custom-domain.com/base-images/dotnet-6.0-sdk As build", version, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk As build");
-            testCases.Add("from docker.custom-domain.com/base-images/dotnet-6.0-sdk as build", version, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk as build");
+            testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS build", channel, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
+            testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS build-env", channel, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build-env");
+            testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0-preview AS build", channel, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
+            testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra AS final", channel, type, true, $"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra AS final");
+            testCases.Add("FROM docker.custom-domain.com/base-images/dotnet-6.0-sdk AS build", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build");
+            testCases.Add("From docker.custom-domain.com/base-images/dotnet-6.0-sdk As build", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk As build");
+            testCases.Add("from docker.custom-domain.com/base-images/dotnet-6.0-sdk as build", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk as build");
 
             // With platform
-            testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0", version, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
-            testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0-preview", version, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
-            testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra", version, type, true, $"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra");
-            testCases.Add("FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk", version, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
-            testCases.Add("From --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk", version, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
-            testCases.Add("from --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk", version, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
+            testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0", channel, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
+            testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0-preview", channel, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
+            testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra");
+            testCases.Add("FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
+            testCases.Add("From --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
+            testCases.Add("from --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
 
             // With platform and name
-            testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0 AS build", version, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
-            testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0-preview AS build", version, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
-            testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0-preview AS build-env", version, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build-env");
-            testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra AS final", version, type, true, $"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra AS final");
-            testCases.Add("FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk AS build", version, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build");
-            testCases.Add("From --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk As build", version, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk As build");
-            testCases.Add("from --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk as build", version, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk as build");
+            testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0 AS build", channel, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
+            testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0-preview AS build", channel, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
+            testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0-preview AS build-env", channel, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build-env");
+            testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra AS final", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra AS final");
+            testCases.Add("FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk AS build", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build");
+            testCases.Add("From --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk As build", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk As build");
+            testCases.Add("from --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk as build", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk as build");
         }
 
         return testCases;
@@ -194,13 +191,16 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
     [MemberData(nameof(DockerImages))]
     public static void TryUpdateImage_Returns_Expected_Values(
         string value,
-        Version channel,
+        string channel,
         DotNetSupportPhase supportPhase,
         bool expectedResult,
         string? expectedImage)
     {
+        // Arrange
+        var channelVersion = Version.Parse(channel);
+
         // Act
-        var actualResult = DockerfileUpgrader.TryUpdateImage(value, channel, supportPhase, out var actualImage);
+        var actualResult = DockerfileUpgrader.TryUpdateImage(value, channelVersion, supportPhase, out var actualImage);
 
         // Assert
         actualResult.ShouldBe(expectedResult);

--- a/tests/DotNetBumper.Tests/Upgraders/RuntimeIdentifierUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/RuntimeIdentifierUpgraderTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Xml.Linq;
-using Microsoft.Build.Utilities.ProjectCreation;
 
 namespace MartinCostello.DotNetBumper.Upgraders;
 
@@ -56,7 +55,8 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
         string expectedValue)
     {
         // Arrange
-        var builder = ProjectCreator.Create(sdk: ProjectCreatorConstants.SdkCsprojDefaultSdk)
+        var builder = Project
+            .Create(hasSdk: true)
             .Property(propertyName, propertyValue);
 
         using var fixture = new UpgraderFixture(outputHelper);
@@ -300,7 +300,8 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
     public async Task UpgradeAsync_Does_Not_Change_DotNet_7_Runtime_Identifiers()
     {
         // Arrange
-        var builder = ProjectCreator.Create(sdk: ProjectCreatorConstants.SdkCsprojDefaultSdk)
+        var builder = Project
+            .Create(hasSdk: true)
             .Property("RuntimeIdentifier", "win10-x64");
 
         var fileContents = builder.Xml;

--- a/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Xml.Linq;
-using Microsoft.Build.Utilities.ProjectCreation;
 
 namespace MartinCostello.DotNetBumper.Upgraders;
 
@@ -59,7 +58,8 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
         string expectedValue)
     {
         // Arrange
-        var builder = ProjectCreator.Create(sdk: ProjectCreatorConstants.SdkCsprojDefaultSdk)
+        var builder = Project
+            .Create(hasSdk: true)
             .Property(propertyName, propertyValue);
 
         using var fixture = new UpgraderFixture(outputHelper);


### PR DESCRIPTION
- Update `ContainerBaseImage` properties for new image versions.
- Refactor `ProjectCreator` usage to reduce duplication.
- Fix xunit analyser suggestion about non-serializable test cases.

Resolves #241.
