### PR TITLE
Remove support for upgrades to .NET 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,6 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
-          7.0.x
           8.0.x
           9.0.x
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,7 +46,6 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
-          7.0.x
           8.0.x
           9.0.x
 
@@ -135,7 +134,6 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
-          7.0.x
           8.0.x
           9.0.x
 

--- a/src/DotNetBumper.Core/Upgraders/RuntimeIdentifierUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/RuntimeIdentifierUpgrader.cs
@@ -35,12 +35,6 @@ internal sealed partial class RuntimeIdentifierUpgrader(
         StatusContext context,
         CancellationToken cancellationToken)
     {
-        if (upgrade.Channel < DotNetVersions.EightPointZero)
-        {
-            // RIDs only need updating if upgrading to .NET 8.0+
-            return ProcessingResult.None;
-        }
-
         Log.UpgradingRuntimeIdentifier(Logger);
 
         var result = ProcessingResult.None;

--- a/tests/DotNetBumper.Tests/DotNetChannelTestData.cs
+++ b/tests/DotNetBumper.Tests/DotNetChannelTestData.cs
@@ -7,9 +7,9 @@ public sealed class DotNetChannelTestData : TheoryData<string>
 {
     public DotNetChannelTestData()
     {
-        const int MinimumVersion = 7;
+        const int MinimumVersion = 8;
 
-        foreach (int version in Enumerable.Range(MinimumVersion, 4))
+        foreach (int version in Enumerable.Range(MinimumVersion, 3))
         {
             Add(version.ToString("N1", CultureInfo.InvariantCulture));
         }

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -29,7 +29,6 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
         var testCases = new TheoryData<BumperTestCase>
         {
             new("7.0.100", ["net6.0", "net7.0"]),
-            new("6.0.100", ["net6.0"], ["--channel=7.0"]),
             new("6.0.100", ["net6.0"], ["--channel=8.0"]),
             new("6.0.100", ["net6.0"], ["--channel=9.0"]),
             new("6.0.100", ["net6.0"], ["--upgrade-type=latest"]),

--- a/tests/DotNetBumper.Tests/IAnsiConsoleExtensionsTests.cs
+++ b/tests/DotNetBumper.Tests/IAnsiConsoleExtensionsTests.cs
@@ -8,18 +8,13 @@ namespace MartinCostello.DotNetBumper;
 
 public static class IAnsiConsoleExtensionsTests
 {
-    public static TheoryData<IEnvironment> Environments()
+    public static TheoryData<bool, bool> Environments()
     {
-        var testCases = new TheoryData<IEnvironment>();
+        var testCases = new TheoryData<bool, bool>();
 
         foreach (bool isLocal in new[] { true, false })
         {
-            var environment = Substitute.For<IEnvironment>();
-
-            environment.IsGitHubActions.Returns(!isLocal);
-            environment.SupportsLinks.Returns(isLocal);
-
-            testCases.Add(environment);
+            testCases.Add(!isLocal, isLocal);
         }
 
         return testCases;
@@ -27,10 +22,11 @@ public static class IAnsiConsoleExtensionsTests
 
     [Theory]
     [MemberData(nameof(Environments))]
-    public static void WriteDisclaimer_Does_Not_Throw(IEnvironment environment)
+    public static void WriteDisclaimer_Does_Not_Throw(bool isGitHubActions, bool supportsLinks)
     {
         // Arrange
         var console = Substitute.For<IAnsiConsole>();
+        var environment = CreateEnvironment(isGitHubActions, supportsLinks);
 
         // Act and Assert
         Should.NotThrow(() => console.WriteDisclaimer(environment, new(8, 0)));
@@ -38,10 +34,11 @@ public static class IAnsiConsoleExtensionsTests
 
     [Theory]
     [MemberData(nameof(Environments))]
-    public static void WriteRuntimeNearingEndOfSupportWarning_Does_Not_Throw(IEnvironment environment)
+    public static void WriteRuntimeNearingEndOfSupportWarning_Does_Not_Throw(bool isGitHubActions, bool supportsLinks)
     {
         // Arrange
         var console = Substitute.For<IAnsiConsole>();
+        var environment = CreateEnvironment(isGitHubActions, supportsLinks);
 
         var upgrade = new UpgradeInfo()
         {
@@ -81,10 +78,11 @@ public static class IAnsiConsoleExtensionsTests
 
     [Theory]
     [MemberData(nameof(Environments))]
-    public static void WriteProgressLine_Does_Not_Throw(IEnvironment environment)
+    public static void WriteProgressLine_Does_Not_Throw(bool isGitHubActions, bool supportsLinks)
     {
         // Arrange
         var console = Substitute.For<IAnsiConsole>();
+        var environment = CreateEnvironment(isGitHubActions, supportsLinks);
 
         // Act and Assert
         Should.NotThrow(() => console.WriteProgressLine(environment, "A progress message."));
@@ -127,5 +125,15 @@ public static class IAnsiConsoleExtensionsTests
 
         // Act and Assert
         Should.NotThrow(() => console.WriteUnsupportedLambdaRuntimeWarning(upgrade));
+    }
+
+    private static IEnvironment CreateEnvironment(bool isGitHubActions, bool supportsLinks)
+    {
+        var environment = Substitute.For<IEnvironment>();
+
+        environment.IsGitHubActions.Returns(isGitHubActions);
+        environment.SupportsLinks.Returns(supportsLinks);
+
+        return environment;
     }
 }

--- a/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
@@ -16,7 +16,6 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
 #pragma warning disable IDE0028 // See https://github.com/dotnet/roslyn/issues/72668
         return new()
         {
-            "7.0",
             "8.0",
             "9.0",
         };

--- a/tests/DotNetBumper.Tests/Upgraders/AwsLambdaToolsUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/AwsLambdaToolsUpgraderTests.cs
@@ -72,6 +72,7 @@ public class AwsLambdaToolsUpgraderTests(ITestOutputHelper outputHelper)
 
     [Theory]
     [InlineData("7.0", DotNetReleaseType.Sts, DotNetSupportPhase.Active)]
+    [InlineData("7.0", DotNetReleaseType.Sts, DotNetSupportPhase.Eol)]
     [InlineData("9.0", DotNetReleaseType.Sts, DotNetSupportPhase.Preview)]
     [InlineData("9.0", DotNetReleaseType.Sts, DotNetSupportPhase.GoLive)]
     [InlineData("9.0", DotNetReleaseType.Sts, DotNetSupportPhase.Active)]

--- a/tests/DotNetBumper.Tests/Upgraders/AwsSamTemplateUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/AwsSamTemplateUpgraderTests.cs
@@ -93,6 +93,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         return new()
         {
             { "7.0", DotNetReleaseType.Sts, DotNetSupportPhase.Active },
+            { "7.0", DotNetReleaseType.Sts, DotNetSupportPhase.Eol },
             { "9.0", DotNetReleaseType.Sts, DotNetSupportPhase.Preview },
             { "9.0", DotNetReleaseType.Sts, DotNetSupportPhase.GoLive },
             { "9.0", DotNetReleaseType.Sts, DotNetSupportPhase.Active },
@@ -197,6 +198,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
 
     [Theory]
     [InlineData("7.0", DotNetReleaseType.Sts, DotNetSupportPhase.Active)]
+    [InlineData("7.0", DotNetReleaseType.Sts, DotNetSupportPhase.Eol)]
     [InlineData("9.0", DotNetReleaseType.Sts, DotNetSupportPhase.Preview)]
     [InlineData("9.0", DotNetReleaseType.Sts, DotNetSupportPhase.GoLive)]
     [InlineData("9.0", DotNetReleaseType.Sts, DotNetSupportPhase.Active)]

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -12,9 +12,8 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 #pragma warning disable IDE0028 // See https://github.com/dotnet/roslyn/issues/72668
         return new()
         {
-            "7.0",
-            //// "8.0", See https://github.com/dotnet/sdk/issues/39742
-            //// "9.0", See https://github.com/dotnet/sdk/issues/39909 and https://github.com/dotnet/sdk/issues/40174
+            "8.0",
+            "9.0",
         };
 #pragma warning restore IDE0028
     }
@@ -23,10 +22,8 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
     [MemberData(nameof(Channels))]
     public async Task UpgradeAsync_Applies_Code_Fix(string channel)
     {
-#if NET9_0_OR_GREATER
-        // HACK For some yet-unknown reason, this test fails with .NET 9
-        Skip.If(true, "Fails with .NET 9.");
-#endif
+        Skip.If(channel is "8.0", "See https://github.com/dotnet/sdk/issues/39742");
+        Skip.If(channel is "9.0", "See https://github.com/dotnet/sdk/issues/39909 and https://github.com/dotnet/sdk/issues/40174");
 
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
@@ -76,10 +73,8 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
     [MemberData(nameof(Channels))]
     public async Task UpgradeAsync_Applies_Code_Fixes(string channel)
     {
-#if NET9_0_OR_GREATER
-        // HACK For some yet-unknown reason, this test fails with .NET 9
-        Skip.If(true, "Fails with .NET 9.");
-#endif
+        Skip.If(channel is "8.0", "See https://github.com/dotnet/sdk/issues/39742");
+        Skip.If(channel is "9.0", "See https://github.com/dotnet/sdk/issues/39909 and https://github.com/dotnet/sdk/issues/40174");
 
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
@@ -129,14 +124,12 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
         actual.ShouldBe(ProcessingResult.None);
     }
 
-    [SkippableTheory(Skip = "Flaky test.")]
+    [SkippableTheory]
     [MemberData(nameof(Channels))]
     public async Task UpgradeAsync_Honors_User_Project_Settings(string channel)
     {
-#if NET9_0_OR_GREATER
-        // HACK For some yet-unknown reason, this test fails with .NET 9
-        Skip.If(true, "Fails with .NET 9.");
-#endif
+        Skip.If(channel is "8.0", "See https://github.com/dotnet/sdk/issues/39742");
+        Skip.If(channel is "9.0", "See https://github.com/dotnet/sdk/issues/39909 and https://github.com/dotnet/sdk/issues/40174");
 
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
@@ -179,10 +172,8 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
     [MemberData(nameof(Channels))]
     public async Task UpgradeAsync_Does_Not_Fix_Information_Diagnostics(string channel)
     {
-#if NET9_0_OR_GREATER
-        // HACK For some yet-unknown reason, this test fails with .NET 9
-        Skip.If(true, "Fails with .NET 9.");
-#endif
+        Skip.If(channel is "8.0", "See https://github.com/dotnet/sdk/issues/39742");
+        Skip.If(channel is "9.0", "See https://github.com/dotnet/sdk/issues/39909 and https://github.com/dotnet/sdk/issues/40174");
 
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);

--- a/tests/DotNetBumper.Tests/Upgraders/PowerShellScriptUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/PowerShellScriptUpgraderTests.cs
@@ -131,8 +131,8 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
             name: build
             on: [push]
             jobs:
-              build:               
-                runs-on: ubuntu-latest             
+              build:
+                runs-on: ubuntu-latest
                 steps:
                   - uses: actions/checkout@v4
                   - uses: actions/setup-dotnet@v3
@@ -145,8 +145,8 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
             name: build
             on: [push]
             jobs:
-              build:               
-                runs-on: ubuntu-latest             
+              build:
+                runs-on: ubuntu-latest
                 steps:
                   - uses: actions/checkout@v4
                   - uses: actions/setup-dotnet@v3
@@ -196,8 +196,8 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
              name: build
              on: [push]
              jobs:
-               build:               
-                 runs-on: ubuntu-latest             
+               build:
+                 runs-on: ubuntu-latest
                  steps:
                    - uses: actions/checkout@v4
                    - uses: actions/setup-dotnet@v3
@@ -211,8 +211,8 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
              name: build
              on: [push]
              jobs:
-               build:               
-                 runs-on: ubuntu-latest             
+               build:
+                 runs-on: ubuntu-latest
                  steps:
                    - uses: actions/checkout@v4
                    - uses: actions/setup-dotnet@v3
@@ -264,8 +264,8 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
 
             jobs:
 
-              build:               
-                runs-on: ubuntu-latest             
+              build:
+                runs-on: ubuntu-latest
                 steps:
 
                   - name: Install .NET
@@ -305,8 +305,8 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
 
             jobs:
 
-              build:               
-                runs-on: ubuntu-latest             
+              build:
+                runs-on: ubuntu-latest
                 steps:
 
                   - name: Install .NET
@@ -378,8 +378,8 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
             name: build
             on: [push]
             jobs:
-              build:               
-                runs-on: ubuntu-latest             
+              build:
+                runs-on: ubuntu-latest
                 steps:
                   - uses: actions/checkout@v4
                   - uses: actions/setup-dotnet@v3

--- a/tests/DotNetBumper.Tests/Upgraders/RuntimeIdentifierUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/RuntimeIdentifierUpgraderTests.cs
@@ -296,40 +296,6 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
         actual.ShouldBe(expected);
     }
 
-    [Fact]
-    public async Task UpgradeAsync_Does_Not_Change_DotNet_7_Runtime_Identifiers()
-    {
-        // Arrange
-        var builder = Project
-            .Create(hasSdk: true)
-            .Property("RuntimeIdentifier", "win10-x64");
-
-        var fileContents = builder.Xml;
-
-        using var fixture = new UpgraderFixture(outputHelper);
-        var projectFile = await fixture.Project.AddFileAsync("Directory.Build.props", fileContents);
-
-        var upgrade = new UpgradeInfo()
-        {
-            Channel = Version.Parse("7.0"),
-            EndOfLife = DateOnly.MaxValue,
-            ReleaseType = DotNetReleaseType.Lts,
-            SdkVersion = new("7.0.100"),
-            SupportPhase = DotNetSupportPhase.Active,
-        };
-
-        var target = CreateTarget(fixture);
-
-        // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
-
-        // Assert
-        actualUpdated.ShouldBe(ProcessingResult.None);
-
-        string actualContent = await File.ReadAllTextAsync(projectFile);
-        actualContent.ShouldBe(fileContents);
-    }
-
     [Theory]
     [ClassData(typeof(FileEncodingTestData))]
     public async Task UpgradeAsync_Preserves_Bom(string newLine, bool hasUtf8Bom)

--- a/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
@@ -11,7 +11,6 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
     {
         string[] channels =
         [
-            "7.0",
             "8.0",
             "9.0",
             "10.0",


### PR DESCRIPTION
- Remove support for upgrading to .NET 7 as it goes out of support on 14th May.
- Fix xunit analyser suggestion about non-serializable test case.
