### PR TITLE
Remove .NET 6 SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,6 @@ jobs:
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
           9.0.x
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,7 +45,6 @@ jobs:
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
           9.0.x
 
@@ -133,7 +132,6 @@ jobs:
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
           9.0.x
 


### PR DESCRIPTION
Remove .NET 6 SDK installation in GitHub Actions workflows as it shouldn't be needed anymore.
