### PR TITLE
Fix testcase

### DIFF
--- a/tests/DotNetBumper.Tests/BumperTestCase.cs
+++ b/tests/DotNetBumper.Tests/BumperTestCase.cs
@@ -55,7 +55,7 @@ public sealed class BumperTestCase(
 
             for (int i = 0; i < references.Length; i++)
             {
-                if (references[i].Split(':') is [var package, var version])
+                if (references[i].Split('=') is [var package, var version])
                 {
                     PackageReferences[package] = version;
                 }


### PR DESCRIPTION
- Fix incorrect character being used to split meaning the package references were never used.
- Fix package assertions not verifying the version.
