### PR TITLE
Log .NET version

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -103,6 +103,11 @@ jobs:
             test: false
             upgrade-type: Preview
             warnings-as-errors: false
+          # alexa-london-travel-site tests disabled due to breaking changes in .NET Aspire not yet in .NET 9 previews
+          - repo: alexa-london-travel-site
+            test: false
+            upgrade-type: Preview
+            warnings-as-errors: false
           # costellobot and dependabot-helper removed due to https://github.com/dotnet/aspire/issues/3941
           - repo: costellobot
             test: false

--- a/src/DotNetBumper.Core/Logging/BumperLogContext.cs
+++ b/src/DotNetBumper.Core/Logging/BumperLogContext.cs
@@ -26,6 +26,11 @@ public sealed class BumperLogContext
     public string? Result { get; set; }
 
     /// <summary>
+    /// Gets or sets the .NET version that was upgraded to.
+    /// </summary>
+    public string? DotNetVersion { get; set; }
+
+    /// <summary>
     /// Gets or sets the version of the .NET SDK that was found to upgrade to, if any.
     /// </summary>
     public string? DotNetSdkVersion { get; set; }

--- a/src/DotNetBumper.Core/Logging/JsonLogWriter.cs
+++ b/src/DotNetBumper.Core/Logging/JsonLogWriter.cs
@@ -30,6 +30,7 @@ internal sealed class JsonLogWriter(string fileName) : FileLogWriter(fileName)
             ["startedAt"] = JsonValue.Create(context.StartedAt),
             ["finishedAt"] = JsonValue.Create(context.FinishedAt),
             ["result"] = JsonValue.Create(context.Result),
+            ["dotnetVersion"] = JsonValue.Create(context.DotNetVersion),
             ["sdkVersion"] = JsonValue.Create(context.DotNetSdkVersion),
         };
 

--- a/src/DotNetBumper.Core/Logging/MarkdownLogWriter.cs
+++ b/src/DotNetBumper.Core/Logging/MarkdownLogWriter.cs
@@ -34,6 +34,11 @@ internal class MarkdownLogWriter(string fileName) : FileLogWriter(fileName)
             await writer.WriteLineAsync($"Project upgraded to .NET SDK `{context.DotNetSdkVersion}`.");
             await writer.WriteLineAsync();
         }
+        else if (context.DotNetVersion is not null)
+        {
+            await writer.WriteLineAsync($"Project upgraded to .NET {context.DotNetVersion}.");
+            await writer.WriteLineAsync();
+        }
 
         if (context.Warnings.Count > 0)
         {

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -67,6 +67,8 @@ public partial class ProjectUpgrader(
             return 0;
         }
 
+        logContext.DotNetVersion = upgrade.Channel.ToString();
+
         var name = Path.GetFileNameWithoutExtension(ProjectPath);
 
         console.MarkupLineInterpolated($"Upgrading project [aqua]{name}[/] to .NET [purple]{upgrade.Channel}[/]...");

--- a/tests/DotNetBumper.Tests/Logging/JsonLogWriterTests.cs
+++ b/tests/DotNetBumper.Tests/Logging/JsonLogWriterTests.cs
@@ -13,6 +13,7 @@ public static class JsonLogWriterTests
         // Arrange
         var context = new BumperLogContext()
         {
+            DotNetVersion = "8.0",
             DotNetSdkVersion = "8.0.201",
             StartedAt = new(2024, 02, 27, 12, 34, 56, TimeSpan.Zero),
             FinishedAt = new(2024, 02, 27, 12, 35, 43, TimeSpan.Zero),
@@ -38,6 +39,7 @@ public static class JsonLogWriterTests
             ("startedAt", "2024-02-27T12:34:56+00:00"),
             ("finishedAt", "2024-02-27T12:35:43+00:00"),
             ("result", "Success"),
+            ("dotnetVersion", "8.0"),
             ("sdkVersion", "8.0.201"),
         };
 

--- a/tests/DotNetBumper.Tests/Logging/MarkdownLogWriterTests.cs
+++ b/tests/DotNetBumper.Tests/Logging/MarkdownLogWriterTests.cs
@@ -11,6 +11,7 @@ public static class MarkdownLogWriterTests
         // Arrange
         var context = new BumperLogContext()
         {
+            DotNetVersion = "8.0",
             DotNetSdkVersion = "8.0.201",
             StartedAt = new(2024, 02, 27, 12, 34, 56, TimeSpan.Zero),
             FinishedAt = new(2024, 02, 27, 12, 35, 43, TimeSpan.Zero),
@@ -33,11 +34,40 @@ public static class MarkdownLogWriterTests
     }
 
     [Fact]
+    public static async Task WriteAsync_Generates_Log_File_When_Successful_With_No_Sdk_Update()
+    {
+        // Arrange
+        var context = new BumperLogContext()
+        {
+            DotNetVersion = "8.0",
+            DotNetSdkVersion = null,
+            StartedAt = new(2024, 02, 27, 12, 34, 56, TimeSpan.Zero),
+            FinishedAt = new(2024, 02, 27, 12, 35, 43, TimeSpan.Zero),
+            Result = nameof(ProcessingResult.Success),
+        };
+
+        var path = Path.GetTempFileName();
+        var target = new MarkdownLogWriter(path);
+
+        // Act
+        await target.WriteAsync(context, CancellationToken.None);
+
+        // Assert
+        File.Exists(path).ShouldBeTrue();
+
+        var contents = await File.ReadAllTextAsync(path);
+        contents.Length.ShouldBeGreaterThan(0);
+
+        contents.ShouldContain("Project upgraded to .NET 8.0.");
+    }
+
+    [Fact]
     public static async Task WriteAsync_Generates_Log_File_When_No_Upgrade()
     {
         // Arrange
         var context = new BumperLogContext()
         {
+            DotNetVersion = "8.0",
             DotNetSdkVersion = "8.0.201",
             StartedAt = new(2024, 02, 27, 12, 34, 56, TimeSpan.Zero),
             FinishedAt = new(2024, 02, 27, 12, 35, 43, TimeSpan.Zero),


### PR DESCRIPTION
Log the version of .NET when upgrading so that if the .NET SDK isn't updated, there's still some signal of the channel associated with the upgrade.
