### PR TITLE
Update actions/setup-dotnet SDK versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,8 +44,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <AssemblyVersion>0.6.0.0</AssemblyVersion>
-    <VersionPrefix>0.6.3</VersionPrefix>
+    <AssemblyVersion>0.7.0.0</AssemblyVersion>
+    <VersionPrefix>0.7.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' ">
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_HEAD_REF)' == '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>

--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IUpgrader, ContainerBaseImageUpgrader>();
         services.AddSingleton<IUpgrader, DockerfileUpgrader>();
         services.AddSingleton<IUpgrader, DotNetCodeUpgrader>();
+        services.AddSingleton<IUpgrader, GitHubActionsUpgrader>();
         services.AddSingleton<IUpgrader, GlobalJsonUpgrader>();
         services.AddSingleton<IUpgrader, PackageVersionUpgrader>();
         services.AddSingleton<IUpgrader, PowerShellScriptUpgrader>();

--- a/src/DotNetBumper.Core/Upgraders/GitHubActionsUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GitHubActionsUpgrader.cs
@@ -273,12 +273,10 @@ internal sealed partial class GitHubActionsUpgrader(
                     {
                         if (TryUpdateVersion(version, out var edited))
                         {
-                            builder.Append(edited);
+                            version = edited;
                         }
-                        else
-                        {
-                            builder.Append(version);
-                        }
+
+                        builder.Append(version);
                     }
 
                     if (i != versions.Length - 1)

--- a/src/DotNetBumper.Core/Upgraders/GitHubActionsUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GitHubActionsUpgrader.cs
@@ -1,0 +1,290 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+using YamlDotNet.RepresentationModel;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+internal sealed partial class GitHubActionsUpgrader(
+    IAnsiConsole console,
+    IEnvironment environment,
+    IOptions<UpgradeOptions> options,
+    ILogger<GitHubActionsUpgrader> logger) : FileUpgrader(console, environment, options, logger)
+{
+    protected override string Action => "Upgrading GitHub Actions workflows";
+
+    protected override string InitialStatus => "Update GitHub Actions";
+
+    protected override IReadOnlyList<string> Patterns { get; } = ["*.yaml", "*.yml"];
+
+    protected override IReadOnlyList<string> FindFiles()
+    {
+        List<string> fileNames = [];
+
+        foreach (string fileName in base.FindFiles())
+        {
+            var directory = PathHelpers.Normalize(Path.GetDirectoryName(fileName) ?? string.Empty);
+
+            if (directory.EndsWith(WellKnownFileNames.GitHubActionsWorkflowsDirectory, StringComparison.OrdinalIgnoreCase))
+            {
+                fileNames.Add(fileName);
+            }
+        }
+
+        return fileNames;
+    }
+
+    protected override async Task<ProcessingResult> UpgradeCoreAsync(
+        UpgradeInfo upgrade,
+        IReadOnlyList<string> fileNames,
+        StatusContext context,
+        CancellationToken cancellationToken)
+    {
+        Log.UpgradingGitHubActionsWorkflows(logger);
+
+        var result = ProcessingResult.None;
+
+        foreach (var path in fileNames)
+        {
+            var editResult = await TryUpgradeAsync(path, upgrade, context, cancellationToken);
+            result = result.Max(editResult);
+        }
+
+        return result;
+    }
+
+    private bool TryParseActionsWorkflow(
+        string fileName,
+        [NotNullWhen(true)] out YamlStream? workflow)
+    {
+        try
+        {
+            workflow = YamlHelpers.ParseFile(fileName);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.ParseActionsWorkflowFailed(logger, fileName, ex);
+            workflow = null;
+            return false;
+        }
+    }
+
+    private async Task<ProcessingResult> TryUpgradeAsync(
+        string path,
+        UpgradeInfo upgrade,
+        StatusContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(cancellationToken);
+
+        var name = RelativeName(path);
+
+        context.Status = StatusMessage($"Parsing {name}...");
+
+        if (!TryParseActionsWorkflow(path, out var workflow))
+        {
+            return ProcessingResult.None;
+        }
+
+        var finder = new SetupDotNetActionFinder(upgrade);
+        workflow.Accept(finder);
+
+        if (finder.LineIndexes.Count is 0)
+        {
+            return ProcessingResult.None;
+        }
+
+        context.Status = StatusMessage($"Updating {name}...");
+
+        await UpdateSdkVersionsAsync(path, finder, cancellationToken);
+
+        return ProcessingResult.Success;
+    }
+
+    private async Task UpdateSdkVersionsAsync(
+        string path,
+        SetupDotNetActionFinder finder,
+        CancellationToken cancellationToken)
+    {
+        using var buffered = new MemoryStream();
+
+        using (var input = FileHelpers.OpenRead(path, out var metadata))
+        using (var reader = new StreamReader(input, metadata.Encoding))
+        using (var writer = new StreamWriter(buffered, metadata.Encoding, leaveOpen: true))
+        {
+            writer.NewLine = metadata.NewLine;
+
+            int i = 0;
+
+            while (await reader.ReadLineAsync(cancellationToken) is { } line)
+            {
+                if (finder.LineIndexes.TryGetValue(i++, out var value))
+                {
+                    var updated = new StringBuilder(line.Length);
+
+                    int index = line.IndexOf(':', StringComparison.Ordinal);
+
+                    Debug.Assert(index != -1, $"The {SetupDotNetActionFinder.VersionPropertyName} line should contain a colon.");
+
+                    updated.Append(line[..(index + 1)]);
+                    updated.Append(' ');
+                    updated.Append(value);
+
+                    // Preserve any comments
+                    index = line.IndexOf('#', StringComparison.Ordinal);
+
+                    if (index != -1)
+                    {
+                        updated.Append(' ');
+                        updated.Append(line[index..]);
+                    }
+
+                    line = updated.ToString();
+                }
+
+                await writer.WriteAsync(line);
+                await writer.WriteLineAsync();
+            }
+
+            await writer.FlushAsync(cancellationToken);
+        }
+
+        buffered.Seek(0, SeekOrigin.Begin);
+
+        await using var output = File.OpenWrite(path);
+
+        await buffered.CopyToAsync(output, cancellationToken);
+        await buffered.FlushAsync(cancellationToken);
+
+        buffered.SetLength(buffered.Position);
+
+        Log.UpgradedSdkVersions(logger, path);
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 1,
+            Level = LogLevel.Debug,
+            Message = "Upgrading GitHub Actions workflows.")]
+        public static partial void UpgradingGitHubActionsWorkflows(ILogger logger);
+
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Warning,
+            Message = "Unable to parse GitHub Actions workflow file {FileName}.")]
+        public static partial void ParseActionsWorkflowFailed(
+            ILogger logger,
+            string fileName,
+            Exception exception);
+
+        [LoggerMessage(
+            EventId = 3,
+            Level = LogLevel.Debug,
+            Message = "Upgraded .NET SDK version for actions/setup-dotnet in {FileName}.")]
+        public static partial void UpgradedSdkVersions(
+            ILogger logger,
+            string fileName);
+    }
+
+    private sealed class SetupDotNetActionFinder(UpgradeInfo upgrade) : YamlVisitorBase
+    {
+        public const string VersionPropertyName = "dotnet-version";
+
+        public Dictionary<int, string> LineIndexes { get; } = [];
+
+        protected override void VisitPair(YamlNode key, YamlNode value)
+        {
+            if (key is YamlScalarNode { Value: "steps" } &&
+                value is YamlSequenceNode { Children.Count: > 0 } items)
+            {
+                foreach (var item in items)
+                {
+                    if (item is not YamlMappingNode { Children.Count: > 0 } step)
+                    {
+                        continue;
+                    }
+
+                    var uses = step.Children.FirstOrDefault((p) => p.Key is YamlScalarNode { Value: "uses" }).Value;
+
+                    if (uses is not YamlScalarNode { Value.Length: > 0 } action)
+                    {
+                        continue;
+                    }
+
+                    if (action.Value?.StartsWith("actions/setup-dotnet@", StringComparison.Ordinal) is false)
+                    {
+                        continue;
+                    }
+
+                    var with = step.Children.FirstOrDefault((p) => p.Key is YamlScalarNode { Value: "with" }).Value;
+
+                    if (with is not YamlMappingNode { Children.Count: > 0 } inputs)
+                    {
+                        continue;
+                    }
+
+                    var dotnetVersion = inputs.Children.FirstOrDefault((p) => p.Key is YamlScalarNode { Value: VersionPropertyName }).Value;
+
+                    if (dotnetVersion is not YamlScalarNode { Value.Length: > 0 } version)
+                    {
+                        continue;
+                    }
+
+                    string[] versionParts = version.Value.Split('.');
+
+                    if (versionParts.Length is not (2 or 3))
+                    {
+                        continue;
+                    }
+
+                    Version? current;
+                    Version target;
+                    bool hasFloatingVersion = false;
+
+                    if (versionParts.Length is 2)
+                    {
+                        if (!Version.TryParse(version.Value, out current))
+                        {
+                            continue;
+                        }
+
+                        target = upgrade.Channel;
+                    }
+                    else
+                    {
+                        Debug.Assert(versionParts.Length is 3, $"Expected 3 version parts but got {versionParts.Length}.");
+
+                        hasFloatingVersion = versionParts[2] is "x";
+                        int length = hasFloatingVersion ? 2 : 3;
+
+                        if (!Version.TryParse(string.Join('.', versionParts[0..length]), out current))
+                        {
+                            continue;
+                        }
+
+                        target = hasFloatingVersion ? upgrade.Channel : upgrade.SdkVersion.Version;
+                    }
+
+                    if (current >= target)
+                    {
+                        continue;
+                    }
+
+                    LineIndexes[dotnetVersion.Start.Line - 1] = hasFloatingVersion
+                        ? $"{target.ToString(2)}.x"
+                        : target.ToString();
+                }
+            }
+
+            base.VisitPair(key, value);
+        }
+    }
+}

--- a/src/DotNetBumper.Core/Upgraders/GitHubActionsUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GitHubActionsUpgrader.cs
@@ -324,22 +324,7 @@ internal sealed partial class GitHubActionsUpgrader(
                         .Where((p) => !string.IsNullOrWhiteSpace(p))
                         .Where((p) => p is not "|")
                         .Select((p) => p.Split(VersionSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                        .Select((p) =>
-                        {
-                            if (p.Length > 3)
-                            {
-                                return
-                                [
-                                    p[0],
-                                    p[1],
-                                    string.Join(VersionSeparator, p[2..]),
-                                ];
-                            }
-                            else
-                            {
-                                return p;
-                            }
-                        })
+                        .Select((p) => p.Length > 3 ? [p[0], p[1], string.Join(VersionSeparator, p[2..])] : p)
                         .ToArray();
 
                     var upgraded = GetUpgradeVersion(sdkVersions, prefix, lastIndex, upgrade.SdkVersion);
@@ -620,8 +605,8 @@ internal sealed partial class GitHubActionsUpgrader(
             {
                 upgradedVersion =
                     targetVersion.IsPrerelease && versionParts.Length is 3 ?
-                    upgradedVersion = targetVersion.ToString() : // Use the exact pre-release version
-                    upgradedVersion = targetVersion.Version.ToString(versionParts.Length); // Truncate the target version to how many version parts the original version specified
+                    targetVersion.ToString() : // Use the exact pre-release version
+                    targetVersion.Version.ToString(versionParts.Length); // Truncate the target version to how many version parts the original version specified
             }
 
             upgradedVersion = prefix + upgradedVersion;

--- a/src/DotNetBumper.Core/Upgraders/GitHubActionsUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GitHubActionsUpgrader.cs
@@ -188,6 +188,7 @@ internal sealed partial class GitHubActionsUpgrader(
         private const int FeatureBandMultiplier = 100;
         private const char FloatingVersionChar = 'x';
         private const string FloatingVersionString = "x";
+        private const char PrereleaseSeparator = '-';
         private const char VersionSeparator = '.';
 
         public List<(Range Location, string Replacement)> Edits { get; } = [];
@@ -307,7 +308,7 @@ internal sealed partial class GitHubActionsUpgrader(
                         {
                             majorVersions.Add(major);
                             lastIndex = i;
-                            hasPrerelease |= version.Contains('-', StringComparison.Ordinal);
+                            hasPrerelease |= version.Contains(PrereleaseSeparator, StringComparison.Ordinal);
                         }
                     }
                 }
@@ -348,7 +349,7 @@ internal sealed partial class GitHubActionsUpgrader(
                         if (hasPrerelease)
                         {
                             // Replace the prerelease version
-                            lastIndex = values.IndexOf(values.Last((p) => p.Contains('-', StringComparison.Ordinal)));
+                            lastIndex = values.IndexOf(values.Last((p) => p.Contains(PrereleaseSeparator, StringComparison.Ordinal)));
                             values[lastIndex] = upgraded;
                         }
                         else if (sdkVersions.Length is 1)
@@ -405,7 +406,7 @@ internal sealed partial class GitHubActionsUpgrader(
                     // Strip-out any pre-release versions from the SDK versions for this major version so
                     // we can consider the version format we need to use based only on the stable versions.
                     sdkVersionsParts = sdkVersionsParts
-                        .Where((p) => p.Length is not 3 || !p[2].Contains('-', StringComparison.Ordinal))
+                        .Where((p) => p.Length is not 3 || !p[2].Contains(PrereleaseSeparator, StringComparison.Ordinal))
                         .ToArray();
                 }
 
@@ -453,7 +454,8 @@ internal sealed partial class GitHubActionsUpgrader(
 
                             if (sdkVersion.IsPrerelease)
                             {
-                                version.Append('-').Append(string.Join(VersionSeparator, sdkVersion.ReleaseLabels));
+                                version.Append(PrereleaseSeparator)
+                                       .Append(string.Join(VersionSeparator, sdkVersion.ReleaseLabels));
                             }
                         }
                     }
@@ -487,7 +489,7 @@ internal sealed partial class GitHubActionsUpgrader(
 
             string[] versionParts = versionString.Split(VersionSeparator);
 
-            if (versionParts.Length > 3 && versionString.Contains('-', StringComparison.Ordinal))
+            if (versionParts.Length > 3 && versionString.Contains(PrereleaseSeparator, StringComparison.Ordinal))
             {
                 // Handle preview versions by adding the preview part to the patch version
                 versionParts =

--- a/src/DotNetBumper.Core/Upgraders/GitHubActionsUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GitHubActionsUpgrader.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using NuGet.Versioning;
 using Spectre.Console;
 using YamlDotNet.RepresentationModel;
 
@@ -123,8 +124,8 @@ internal sealed partial class GitHubActionsUpgrader(
 
         static string Update(SetupDotNetActionFinder finder)
         {
-            var contents = finder.Workflow.AsSpan();
-            var builder = new StringBuilder(contents.Length);
+            var remaining = finder.Contents.AsSpan();
+            var edited = new StringBuilder(remaining.Length);
 
             int offset = 0;
 
@@ -135,21 +136,21 @@ internal sealed partial class GitHubActionsUpgrader(
                 int length = location.End.Value - location.Start.Value;
 
                 // Add the existing content before the edit
-                builder.Append(contents[..index]);
+                edited.Append(remaining[..index]);
 
                 // Add the replacement text
-                builder.Append(replacement);
+                edited.Append(replacement);
 
                 // Consume the used content and update the offset to account
                 // for possible different lengths of content being replaced.
-                contents = contents[(index + length)..];
+                remaining = remaining[(index + length)..];
                 offset += index + length;
             }
 
             // Add any remaning content after the last edit
-            builder.Append(contents);
+            edited.Append(remaining);
 
-            return builder.ToString();
+            return edited.ToString();
         }
     }
 
@@ -180,15 +181,20 @@ internal sealed partial class GitHubActionsUpgrader(
             string fileName);
     }
 
-    private sealed class SetupDotNetActionFinder(UpgradeInfo upgrade, FileMetadata metadata, string workflow) : YamlVisitorBase
+    private sealed class SetupDotNetActionFinder(UpgradeInfo upgrade, FileMetadata metadata, string contents) : YamlVisitorBase
     {
         public const string VersionPropertyName = "dotnet-version";
 
+        private const int FeatureBandMultiplier = 100;
+        private const char FloatingVersionChar = 'x';
+        private const string FloatingVersionString = "x";
+        private const char VersionSeparator = '.';
+
         public List<(Range Location, string Replacement)> Edits { get; } = [];
 
-        public FileMetadata Metadata { get; } = metadata;
+        public string Contents { get; set; } = contents;
 
-        public string Workflow { get; set; } = workflow;
+        public FileMetadata Metadata { get; } = metadata;
 
         protected override void VisitPair(YamlNode key, YamlNode value)
         {
@@ -216,7 +222,7 @@ internal sealed partial class GitHubActionsUpgrader(
                         continue;
                     }
 
-                    TryUpdateVersion(version);
+                    TryUpdateVersions(version);
                 }
             }
 
@@ -245,64 +251,186 @@ internal sealed partial class GitHubActionsUpgrader(
             }
         }
 
-        private void TryUpdateVersion(YamlScalarNode dotnetVersion)
+        private static int FeatureBandFloor(int value)
         {
-            string original = Workflow[dotnetVersion.Start.Index..dotnetVersion.End.Index];
-            string[] versions = original.Split(Metadata.NewLine);
+            // Convert 1xx to 100, 2xx to 200, etc.
+            value /= FeatureBandMultiplier;
+            value *= FeatureBandMultiplier;
+            return value;
+        }
 
-            var builder = new StringBuilder();
+        private void TryUpdateVersions(YamlScalarNode node)
+        {
+            string original = Contents[node.Start.Index..node.End.Index];
+            List<string> values = [.. original.Split(Metadata.NewLine)];
 
-            if (versions.Length is 1)
+            var content = new StringBuilder(original.Length);
+
+            if (values.Count is 1)
             {
-                string version = versions[0];
+                // Only one version is specifed, so we just attempt to update it
+                string version = values[0];
 
                 if (TryUpdateVersion(version, out var edited))
                 {
                     version = edited;
                 }
 
-                builder.Append(version);
+                content.Append(version);
             }
-            else if (versions.Length > 1)
+            else if (values.Count > 1)
             {
-                for (int i = 0; i < versions.Length; i++)
+                // A multi-line string was specified, which may contain multiple versions.
+                // Scan through all the values to find the distinct major versions and make
+                // a note of the index of the last version in the list to either insert a
+                // new version after or replace if there is only one version in the value.
+                HashSet<int> majorVersions = [];
+                int lastIndex = -1;
+
+                for (int i = 0; i < values.Count; i++)
                 {
-                    var version = versions[i];
+                    var version = values[i];
+
+                    if (!string.IsNullOrWhiteSpace(version))
+                    {
+                        var index = version.AsSpan().IndexOfAny(Digits);
+
+                        if (index is -1)
+                        {
+                            continue;
+                        }
+
+                        var first = version[index..].Split('.')[0];
+
+                        if (int.TryParse(first, NumberStyles.None, CultureInfo.InvariantCulture, out var major))
+                        {
+                            majorVersions.Add(major);
+                            lastIndex = i;
+                        }
+                    }
+                }
+
+                // Do we not already have a version for the upgrade version?
+                if (!majorVersions.Contains(upgrade.SdkVersion.Major))
+                {
+                    var index = values[lastIndex].AsSpan().IndexOfAny(Digits);
+                    var prefix = values[lastIndex][..index];
+
+                    // Get all the unique version numbers and split into their parts
+                    var sdkVersions = values
+                        .Where((p) => !string.IsNullOrWhiteSpace(p))
+                        .Where((p) => p is not "|")
+                        .Select((p) => p.Split(VersionSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                        .ToArray();
+
+                    var upgraded = GetUpgradeVersion(sdkVersions, prefix, lastIndex, upgrade.SdkVersion);
+
+                    if (!values.Contains(upgraded))
+                    {
+                        if (sdkVersions.Length is 1)
+                        {
+                            // Even though the value was a multi-line string
+                            // there was only one version, so just replace it.
+                            values[lastIndex] = upgraded;
+                        }
+                        else
+                        {
+                            // Add the new version at the last version in the list
+                            values.Insert(lastIndex + 1, upgraded);
+                        }
+                    }
+                }
+
+                // Create the updated content from the edited/updated versions
+                for (int i = 0; i < values.Count; i++)
+                {
+                    var version = values[i];
 
                     if (!string.IsNullOrEmpty(version))
                     {
-                        if (TryUpdateVersion(version, out var edited))
-                        {
-                            version = edited;
-                        }
-
-                        builder.Append(version);
+                        content.Append(version);
                     }
 
-                    if (i != versions.Length - 1)
+                    if (i != values.Count - 1)
                     {
-                        builder.Append(Metadata.NewLine);
+                        content.Append(Metadata.NewLine);
                     }
                 }
             }
 
-            string updated = builder.ToString();
+            string updated = content.ToString();
 
             if (updated != original)
             {
-                Edits.Add((new(dotnetVersion.Start.Index, dotnetVersion.End.Index), updated));
+                Edits.Add((new(node.Start.Index, node.End.Index), updated));
+            }
+
+            static string GetUpgradeVersion(
+                string[][] sdkVersionsParts,
+                string prefix,
+                int lastIndex,
+                NuGetVersion sdkVersion)
+            {
+                // At a minimum we need the prefix and the major version
+                var version = new StringBuilder()
+                    .Append(prefix)
+                    .Append(sdkVersion.Major);
+
+                // Only add more parts if any one of the versions has more than one
+                if (!sdkVersionsParts.All((p) => p.Length is 1))
+                {
+                    version.Append('.');
+
+                    if (sdkVersionsParts.All((p) => p.Length is 2))
+                    {
+                        if (sdkVersionsParts.All((p) => p[1] is FloatingVersionString))
+                        {
+                            // All versions are of the format "6.x"
+                            version.Append(FloatingVersionChar);
+                        }
+                        else
+                        {
+                            // Use the minor version from the upgrade SDK version
+                            version.Append(sdkVersion.Minor);
+                        }
+                    }
+                    else
+                    {
+                        version.Append(sdkVersion.Minor)
+                               .Append('.');
+
+                        if (sdkVersionsParts.All((p) => p[2] is FloatingVersionString))
+                        {
+                            // All versions are of the format "6.0.x"
+                            version.Append(FloatingVersionChar);
+                        }
+                        else if (sdkVersionsParts.All((p) => p[2].EndsWith(FloatingVersionChar)))
+                        {
+                            // All versions are of the format "6.0.1xx"
+                            int featureBand = (FeatureBandFloor(sdkVersion.Patch) / FeatureBandMultiplier) + '0';
+
+                            version.Append((char)featureBand)
+                                   .Append(FloatingVersionChar)
+                                   .Append(FloatingVersionChar);
+                        }
+                        else
+                        {
+                            // At least one version is fully-qualified (e.g.6.0.100)
+                            version.Append(sdkVersion.Patch);
+                        }
+                    }
+                }
+
+                return version.ToString();
             }
         }
 
         private bool TryUpdateVersion(string content, [NotNullWhen(true)] out string? updated)
         {
-            const int FeatureBandMultiplier = 100;
-            const char FloatingVersionChar = 'x';
-            const string FloatingVersionString = "x";
-            const char VersionSeparator = '.';
-
             updated = null;
 
+            // Find where the version starts in the string as it may
+            // contain leading whitespace if it's a multi-line value.
             int index = content.AsSpan().IndexOfAny(Digits);
 
             string prefix;
@@ -331,18 +459,14 @@ internal sealed partial class GitHubActionsUpgrader(
                 versionParts.Length > 1 &&
                 versionParts[^1].EndsWith(FloatingVersionChar);
 
-            int upgradeFeature = 0;
-
-            if (hasFloatingVersion)
-            {
-                upgradeFeature = FeatureBandFloor(upgrade.SdkVersion.Patch);
-            }
+            int targetFeature = upgrade.SdkVersion.Patch;
 
             Version? currentVersion;
             Version targetVersion;
 
             if (versionParts.Length is 1)
             {
+                // The version should be of the format "6"
                 if (!int.TryParse(versionString, NumberStyles.None, CultureInfo.InvariantCulture, out int major))
                 {
                     return false;
@@ -356,15 +480,18 @@ internal sealed partial class GitHubActionsUpgrader(
             {
                 if (hasFloatingVersion)
                 {
+                    // The version should be of the format "6.x"
                     if (!int.TryParse(versionParts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int major))
                     {
                         return false;
                     }
 
+                    // Treat "6.x" as "6.0" to get the lowest possible version
                     currentVersion = new(major, 0);
                 }
                 else if (!Version.TryParse(versionString, out currentVersion))
                 {
+                    // The version was not of the format "6.0"
                     return false;
                 }
 
@@ -376,22 +503,28 @@ internal sealed partial class GitHubActionsUpgrader(
 
                 if (hasFloatingVersion)
                 {
+                    // The version should be of the format "6.0.x" or "6.0.1xx"
                     if (!Version.TryParse(string.Join(VersionSeparator, versionParts[0..2]), out var majorMinor))
                     {
                         return false;
                     }
 
-                    // Treat "6.0.x" as "6.0.100", "6.0.2x" as "6.0.200", etc.
+                    string feature = versionParts[^1];
+
+                    // Treat "6.0.x" as "6.0.100", "6.0.1xx" as "6.0.100", "6.0.2x" as "6.0.200", etc.
                     int currentFeature =
-                        versionParts[^1] == FloatingVersionString ?
+                        feature == FloatingVersionString ?
                         FeatureBandMultiplier :
-                        (versionParts[^1][0] - '0') * FeatureBandMultiplier;
+                        (feature[0] - '0') * FeatureBandMultiplier;
 
                     currentVersion = new(majorMinor.Major, majorMinor.Minor, currentFeature);
-                    targetVersion = new(upgrade.Channel.Major, upgrade.Channel.Minor, upgradeFeature);
+
+                    targetFeature = FeatureBandFloor(upgrade.SdkVersion.Patch);
+                    targetVersion = new(upgrade.SdkVersion.Major, upgrade.SdkVersion.Minor, targetFeature);
                 }
                 else
                 {
+                    // The version should be of the format "6.0.100"
                     if (!Version.TryParse(versionString, out currentVersion))
                     {
                         return false;
@@ -417,11 +550,13 @@ internal sealed partial class GitHubActionsUpgrader(
 
                 if (versionParts[^1] is FloatingVersionString)
                 {
+                    // The version specified in the last part ".x" so keep it as ".x"
                     upgradedVersion += FloatingVersionString;
                 }
                 else
                 {
-                    char featureBand = (char)('0' + (upgradeFeature / FeatureBandMultiplier));
+                    // The version specified in the last part ".1xx" so keep it as ".Nxx"
+                    char featureBand = (char)('0' + (targetFeature / FeatureBandMultiplier));
                     upgradedVersion += string.Create(3, featureBand, static (span, first) =>
                     {
                         span[0] = first;
@@ -440,19 +575,12 @@ internal sealed partial class GitHubActionsUpgrader(
 
             if (upgradedVersion == versionString)
             {
+                // Nothing was updated
                 return false;
             }
 
             updated = upgradedVersion;
             return true;
-
-            static int FeatureBandFloor(int value)
-            {
-                // Convert 1xx to 100, 2xx to 200, etc.
-                value /= FeatureBandMultiplier;
-                value *= FeatureBandMultiplier;
-                return value;
-            }
         }
     }
 }

--- a/src/DotNetBumper.Core/Upgraders/PowerShellScriptUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PowerShellScriptUpgrader.cs
@@ -52,7 +52,7 @@ internal sealed partial class PowerShellScriptUpgrader(
         {
             var directory = PathHelpers.Normalize(Path.GetDirectoryName(path) ?? string.Empty);
 
-            if (!directory.EndsWith(".github/workflows", StringComparison.OrdinalIgnoreCase) ||
+            if (!directory.EndsWith(WellKnownFileNames.GitHubActionsWorkflowsDirectory, StringComparison.OrdinalIgnoreCase) ||
                 !TryParseActionsWorkflow(path, out workflow))
             {
                 return ProcessingResult.None;

--- a/src/DotNetBumper.Core/WellKnownFileNames.cs
+++ b/src/DotNetBumper.Core/WellKnownFileNames.cs
@@ -13,6 +13,7 @@ internal static class WellKnownFileNames
 
     public const string AwsLambdaToolsDefaults = "aws-lambda-tools-defaults.json";
     public const string DirectoryBuildProps = "Directory.Build.props";
+    public const string GitHubActionsWorkflowsDirectory = ".github/workflows";
     public const string GlobalJson = "global.json";
     public const string ToolsManifest = "dotnet-tools.json";
 }

--- a/tests/DotNetBumper.Tests/Upgraders/GitHubActionsUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/GitHubActionsUpgraderTests.cs
@@ -84,15 +84,27 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData("6", "10")]
-    [InlineData("6.x", "10.x")]
-    [InlineData("6.0", "10.0")]
-    [InlineData("6.0.x", "10.0.x")]
-    [InlineData("6.0.4xx", "10.0.2xx")]
-    [InlineData("6.0.422", "10.0.200")]
-    [InlineData("10.0.1xx", "10.0.2xx")]
-    [InlineData("10.0.100", "10.0.200")]
-    public async Task UpgradeAsync_Upgrades_Setup_DotNet_Action_Sdk_Version(string version, string expected)
+    [InlineData("10.0", "10.0.100", "6", "10")]
+    [InlineData("10.0", "10.0.100", "6.x", "10.x")]
+    [InlineData("10.0", "10.0.100", "6.0", "10.0")]
+    [InlineData("10.0", "10.0.100", "6.0.x", "10.0.x")]
+    [InlineData("10.0", "10.0.200", "6.0.4xx", "10.0.2xx")]
+    [InlineData("10.0", "10.0.200", "6.0.422", "10.0.200")]
+    [InlineData("10.0", "10.0.200", "10.0.1xx", "10.0.2xx")]
+    [InlineData("10.0", "10.0.200", "10.0.100", "10.0.200")]
+    [InlineData("10.0", "10.0.100-preview.1.2", "6", "10")]
+    [InlineData("10.0", "10.0.100-preview.1.2", "6.x", "10.x")]
+    [InlineData("10.0", "10.0.100-preview.1.2", "6.0", "10.0")]
+    [InlineData("10.0", "10.0.100-preview.1.2", "6.0.x", "10.0.x")]
+    [InlineData("10.0", "10.0.100-preview.1.2", "6.0.4xx", "10.0.1xx")]
+    [InlineData("10.0", "10.0.100-preview.1.2", "6.0.422", "10.0.100-preview.1.2")]
+    [InlineData("10.0", "10.0.100-preview.2.3", "10.0.100-preview.1.2", "10.0.100-preview.2.3")]
+    [InlineData("10.0", "10.0.100", "10.0.100-preview.1.2", "10.0.100")]
+    public async Task UpgradeAsync_Upgrades_Setup_DotNet_Action_Sdk_Version(
+        string channel,
+        string sdkVersion,
+        string version,
+        string expected)
     {
         // Arrange
         string fileContents =
@@ -143,10 +155,10 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
 
         var upgrade = new UpgradeInfo()
         {
-            Channel = Version.Parse("10.0"),
+            Channel = Version.Parse(channel),
             EndOfLife = DateOnly.MaxValue,
             ReleaseType = DotNetReleaseType.Lts,
-            SdkVersion = new("10.0.200"),
+            SdkVersion = new(sdkVersion),
             SupportPhase = DotNetSupportPhase.Active,
         };
 
@@ -285,6 +297,7 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
     [InlineData("9.0", "9.0.200", ".0.423", "9.0.200")]
     [InlineData("9.0", "9.0.234", ".0.423", "9.0.234")]
     [InlineData("9.0", "9.0.200", ".0.4xx", "9.0.2xx")]
+    [InlineData("9.0", "9.0.100-preview.1.2", ".0.4xx", "9.0.1xx")]
     [InlineData("10.0", "10.0.100", "", "10")]
     [InlineData("10.0", "10.0.100", ".0", "10.0")]
     [InlineData("10.0", "10.0.100", ".x", "10.x")]
@@ -294,6 +307,7 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
     [InlineData("10.0", "10.0.200", ".0.423", "10.0.200")]
     [InlineData("10.0", "10.0.234", ".0.423", "10.0.234")]
     [InlineData("10.0", "10.0.200", ".0.4xx", "10.0.2xx")]
+    [InlineData("10.0", "10.0.100-preview.1.2", ".0.4xx", "10.0.1xx")]
     public async Task UpgradeAsync_Upgrades_Setup_DotNet_Action_With_Multiple_Sdk_Versions(
         string channel,
         string sdkVersion,

--- a/tests/DotNetBumper.Tests/Upgraders/GitHubActionsUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/GitHubActionsUpgraderTests.cs
@@ -168,6 +168,119 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         actualUpdated.ShouldBe(ProcessingResult.None);
     }
 
+    [Theory]
+    [InlineData("9.0")]
+    [InlineData("10.0")]
+    public async Task UpgradeAsync_Upgrades_Setup_DotNet_Action_With_Multiple_Sdk_Versions(string channel)
+    {
+        // Arrange
+        string fileContents =
+            $"""
+             name: build
+             on: [push]
+
+             jobs:
+               build:
+                 runs-on: ubuntu-latest
+
+                 steps:
+                   - uses: actions/checkout@v4
+                   - name: Setup .NET
+                     uses: actions/setup-dotnet@v4
+                     with:
+                       dotnet-version: |
+                         6.0.x
+                         8.0.x
+
+                   - name: Publish app
+                     shell: pwsh
+                     run: dotnet publish
+             
+               test:
+                 runs-on: ubuntu-latest
+             
+                 steps:
+                   - uses: actions/checkout@v4
+                   - uses: actions/setup-dotnet@v4
+                     with:
+                       dotnet-version: |
+                         6.0.x
+                         8.0.x
+
+                   - name: Test app
+                     run: dotnet test
+             """;
+
+        string expectedContents =
+            $"""
+             name: build
+             on: [push]
+             
+             jobs:
+               build:
+                 runs-on: ubuntu-latest
+             
+                 steps:
+                   - uses: actions/checkout@v4
+                   - name: Setup .NET
+                     uses: actions/setup-dotnet@v4
+                     with:
+                       dotnet-version: |
+                         6.0.x
+                         8.0.x
+                         {channel}.x
+
+                   - name: Publish app
+                     shell: pwsh
+                     run: dotnet publish
+
+               test:
+                 runs-on: ubuntu-latest
+             
+                 steps:
+                   - uses: actions/checkout@v4
+                   - uses: actions/setup-dotnet@v4
+                     with:
+                       dotnet-version: |
+                         6.0.x
+                         8.0.x
+                         {channel}.x
+
+                   - name: Test app
+                     run: dotnet test
+             """;
+
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string workflow = await fixture.Project.AddFileAsync(".github/workflows/build.yml", fileContents);
+
+        var upgrade = new UpgradeInfo()
+        {
+            Channel = Version.Parse(channel),
+            EndOfLife = DateOnly.MaxValue,
+            ReleaseType = DotNetReleaseType.Lts,
+            SdkVersion = new($"{channel}.200"),
+            SupportPhase = DotNetSupportPhase.Active,
+        };
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBe(ProcessingResult.Success);
+
+        string actualContent = await File.ReadAllTextAsync(workflow);
+        actualContent.TrimEnd().ShouldBe(expectedContents.TrimEnd());
+
+        // Act
+        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+
+        // Assert
+        actualUpdated.ShouldBe(ProcessingResult.None);
+    }
+
     [Fact]
     public async Task UpgradeAsync_Ignores_Actions_Workflows_With_No_Setup_DotNet_Action()
     {
@@ -298,7 +411,8 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
     [InlineData("a")]
     [InlineData("a.b")]
     [InlineData("a.b.c")]
-    [InlineData("6.0.y")]
+    [InlineData("6.a")]
+    [InlineData("6.0.a")]
     public async Task UpgradeAsync_Handles_Invalid_Versions(string version)
     {
         // Arrange


### PR DESCRIPTION
Support for updating the .NET SDK version installed by `actions/setup-dotnet` when it is explicitly specified.

Resolves #278.
