### PR TITLE
Add package publish automation

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,13 +13,6 @@
       "commands": [
         "dotnet-validate"
       ]
-    },
-    "MartinCostello.WaitForNuGetPackage": {
-      "version": "1.0.0",
-      "commands": [
-        "dotnet-wait-for-package"
-      ],
-      "rollForward": false
     }
   }
 }

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,13 @@
       "commands": [
         "dotnet-validate"
       ]
+    },
+    "MartinCostello.WaitForNuGetPackage": {
+      "version": "1.0.0",
+      "commands": [
+        "dotnet-wait-for-package"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
       dotnet-validate-version: ${{ steps.get-dotnet-validate-version.outputs.dotnet-validate-version }}
+      package-names: ${{ steps.build.outputs.package-names }}
+      package-version: ${{ steps.build.outputs.package-version }}
 
     permissions:
       attestations: write
@@ -80,6 +82,7 @@ jobs:
         dotnet tool install --global dotnet-outdated-tool --version "$dotnetOutdatedVersion"
 
     - name: Build, Test and Package
+      id: build
       shell: pwsh
       run: ./build.ps1
 
@@ -223,3 +226,16 @@ jobs:
         API_KEY: ${{ secrets.NUGET_TOKEN }}
         SOURCE: https://api.nuget.org/v3/index.json
       run: dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}"
+
+    - name: Publish nuget_packages_published
+      uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+      with:
+        event-type: nuget_packages_published
+        repository: ${{ github.repository_owner }}/github-automation
+        token: ${{ secrets.COSTELLOBOT_TOKEN }}
+        client-payload: |-
+          {
+            "repository": "${{ github.repository }}",
+            "packages": "${{ needs.build.outputs.package-names }}",
+            "version": "${{ needs.build.outputs.package-version }}"
+          }

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -43,4 +43,24 @@
     </PropertyGroup>
     <WriteLinesToFile Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' " ContinueOnError="WarnAndContinue" File="$(GITHUB_STEP_SUMMARY)" Lines="$(_ReportSummaryContent)" />
   </Target>
+  <Target Name="SetNuGetPackageOutputs" AfterTargets="Pack" Condition=" '$(GITHUB_OUTPUT)' != '' ">
+    <PropertyGroup>
+      <_PackageNamesPath>$(ArtifactsPath)\package-names.txt</_PackageNamesPath>
+    </PropertyGroup>
+    <ReadLinesFromFile File="$(_PackageNamesPath)">
+      <Output TaskParameter="Lines" ItemName="_PackageNames" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_PackageNames Include="$(PackageId)" />
+    </ItemGroup>
+    <RemoveDuplicates Inputs="@(_PackageNames)">
+      <Output TaskParameter="Filtered" ItemName="_UniquePackageNames" />
+    </RemoveDuplicates>
+    <PropertyGroup>
+      <_UniquePackageNames>@(_UniquePackageNames->'%(Identity)', ',')</_UniquePackageNames>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_PackageNamesPath)" Lines="@(_UniquePackageNames)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="package-names=$(_UniquePackageNames)" />
+    <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="package-version=$(Version)" />
+  </Target>
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -112,7 +112,7 @@ ForEach ($project in $packageProjects) {
     DotNetPack $project $Configuration
 }
 
-if ($SkipTests -eq $false) {
+if (-Not $SkipTests) {
     Write-Host "Testing $($testProjects.Count) project(s)..." -ForegroundColor Green
     ForEach ($project in $testProjects) {
         DotNetTest $project


### PR DESCRIPTION
Extend the build workflow to output the NuGet package name and version and then dispatch a `nuget_packages_published` event when the NuGet package is published to NuGet.org.
