### PR TITLE
.NET 9 preparation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,6 @@
     <AnalysisMode>All</AnalysisMode>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)DotNetBumper.snk</AssemblyOriginatorKeyFile>
     <Authors>martin_costello</Authors>
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)DotNetBumper.ruleset</CodeAnalysisRuleSet>
     <Company>https://github.com/martincostello/dotnet-bumper</Company>

--- a/src/DotNetBumper.Core/DotNetBumper.Core.csproj
+++ b/src/DotNetBumper.Core/DotNetBumper.Core.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="System.Management.Automation" />
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>

--- a/src/DotNetBumper.Core/ILoggerExtensions.cs
+++ b/src/DotNetBumper.Core/ILoggerExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+#pragma warning disable IDE0130
 namespace Microsoft.Extensions.Logging;
 
 internal static class ILoggerExtensions

--- a/src/DotNetBumper.Core/TargetFrameworkHelpers.cs
+++ b/src/DotNetBumper.Core/TargetFrameworkHelpers.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace MartinCostello.DotNetBumper.Upgraders;
+namespace MartinCostello.DotNetBumper;
 
 internal static class TargetFrameworkHelpers
 {

--- a/tests/DotNetBumper.Tests/JsonNodeExtensions.cs
+++ b/tests/DotNetBumper.Tests/JsonNodeExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Serialization.Metadata;
 
+#pragma warning disable IDE0130
 namespace System.Text.Json.Nodes;
 
 internal static class JsonNodeExtensions

--- a/tests/DotNetBumper.Tests/ProjectCreatorExtensions.cs
+++ b/tests/DotNetBumper.Tests/ProjectCreatorExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+#pragma warning disable IDE0130
 namespace Microsoft.Build.Utilities.ProjectCreation;
 
 internal static class ProjectCreatorExtensions


### PR DESCRIPTION
- Disable `CentralPackageTransitivePinningEnabled` as it causes issues when multi-targeting and instead add an explicit package reference.
- Fix or suppress `IDE0130` warnings.
