### PR TITLE
Set DOTNET_ROLL_FORWARD for tests

### DIFF
--- a/src/DotNetBumper.Core/DotNetProcess.cs
+++ b/src/DotNetBumper.Core/DotNetProcess.cs
@@ -96,8 +96,8 @@ public sealed partial class DotNetProcess(ILogger<DotNetProcess> logger)
         {
             EnvironmentVariables =
             {
-                ["DOTNET_ROLL_FORWARD"] = "Minor",
-                ["MSBuildSDKsPath"] = null,
+                [WellKnownEnvironmentVariables.DotNetRollForward] = "Minor",
+                [WellKnownEnvironmentVariables.MSBuildSdksPath] = null,
                 [BumperBuildLogger.LoggerFilePathVariableName] = customLoggerFileName,
             },
             RedirectStandardError = true,

--- a/src/DotNetBumper.Core/MSBuildHelper.cs
+++ b/src/DotNetBumper.Core/MSBuildHelper.cs
@@ -18,7 +18,7 @@ internal static class MSBuildHelper
 
     public static void TryAddSdkProperties(IDictionary<string, string?> environment, string sdkVersion)
     {
-        var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+        var dotnetRoot = Environment.GetEnvironmentVariable(WellKnownEnvironmentVariables.DotNetRoot);
 
         if (string.IsNullOrEmpty(dotnetRoot))
         {
@@ -37,8 +37,8 @@ internal static class MSBuildHelper
             return;
         }
 
-        environment["MSBUILD_EXE_PATH"] = Path.Combine(dotNetSdkPath, "MSBuild.dll");
-        environment["MSBuildExtensionsPath"] = dotNetSdkPath;
-        environment["MSBuildSDKsPath"] = Path.Combine(dotNetSdkPath, "Sdks");
+        environment[WellKnownEnvironmentVariables.MSBuildExePath] = Path.Combine(dotNetSdkPath, "MSBuild.dll");
+        environment[WellKnownEnvironmentVariables.MSBuildExtensionsPath] = dotNetSdkPath;
+        environment[WellKnownEnvironmentVariables.MSBuildSdksPath] = Path.Combine(dotNetSdkPath, "Sdks");
     }
 }

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -185,7 +185,7 @@ internal sealed partial class DotNetTestPostProcessor(
             // Otherwise this can create issues with using .NET local tools,
             // for example using Microsoft.Extensions.ApiDescription.Server
             // to generate an OpenAPI document as part of building an app.
-            environmentVariables["DOTNET_ROLL_FORWARD"] = "Major";
+            environmentVariables[WellKnownEnvironmentVariables.DotNetRollForward] = "Major";
         }
 
         MSBuildHelper.TryAddSdkProperties(environmentVariables, sdkVersion.ToString());
@@ -195,7 +195,7 @@ internal sealed partial class DotNetTestPostProcessor(
         if (configuration.NoWarn is { Count: > 0 } noWarn)
         {
             propertiesOverrides = await GenerateDirectoryBuildPropsAsync(sdkVersion, noWarn, cancellationToken);
-            environmentVariables["DirectoryBuildPropsPath"] = propertiesOverrides.Path;
+            environmentVariables[WellKnownEnvironmentVariables.DirectoryBuildPropertiesPath] = propertiesOverrides.Path;
         }
 
         string[] arguments =

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -179,6 +179,15 @@ internal sealed partial class DotNetTestPostProcessor(
             [BumperTestLogger.LoggerDirectoryPathVariableName] = logsDirectory.Path,
         };
 
+        if (sdkVersion.IsPrerelease)
+        {
+            // Enable roll-forward for pre-release versions of the .NET SDK.
+            // Otherwise this can create issues with using .NET local tools,
+            // for example using Microsoft.Extensions.ApiDescription.Server
+            // to generate an OpenAPI document as part of building an app.
+            environmentVariables["DOTNET_ROLL_FORWARD"] = "Major";
+        }
+
         MSBuildHelper.TryAddSdkProperties(environmentVariables, sdkVersion.ToString());
 
         TemporaryFile? propertiesOverrides = null;

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -100,7 +100,7 @@ internal sealed partial class DotNetCodeUpgrader(
 
         var environmentVariables = new Dictionary<string, string?>()
         {
-            ["NoWarn"] = "CA1515", // HACK Ignore CA1515 from .NET 9 as it seems to just break things
+            [WellKnownEnvironmentVariables.NoWarn] = "CA1515", // HACK Ignore CA1515 from .NET 9 as it seems to just break things
         };
 
         MSBuildHelper.TryAddSdkProperties(environmentVariables, globalJson?.SdkVersion ?? sdkVersion.ToString());

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -209,14 +209,14 @@ internal sealed partial class PackageVersionUpgrader(
 
         var environmentVariables = new Dictionary<string, string?>(2)
         {
-            ["DOTNET_ROLL_FORWARD"] = "Major",
+            [WellKnownEnvironmentVariables.DotNetRollForward] = "Major",
         };
 
         MSBuildHelper.TryAddSdkProperties(environmentVariables, sdkVersion.ToString());
 
         if (configuration.NoWarn.Count > 0)
         {
-            environmentVariables["NoWarn"] = string.Join(";", configuration.NoWarn);
+            environmentVariables[WellKnownEnvironmentVariables.NoWarn] = string.Join(";", configuration.NoWarn);
         }
 
         var result = await dotnet.RunAsync(directory, ["outdated", .. arguments], environmentVariables, cancellationToken);
@@ -287,7 +287,7 @@ internal sealed partial class PackageVersionUpgrader(
 
         var environment = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
         {
-            ["SkipResolvePackageAssets"] = bool.TrueString,
+            [WellKnownEnvironmentVariables.SkipResolvePackageAssets] = bool.TrueString,
         };
 
         MSBuildHelper.TryAddSdkProperties(environment, sdkVersion.ToString());

--- a/src/DotNetBumper.Core/WellKnownEnvironmentVariables.cs
+++ b/src/DotNetBumper.Core/WellKnownEnvironmentVariables.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper;
+
+/// <summary>
+/// A class containing the names of well-known environment variables. This class cannot be inherited.
+/// </summary>
+internal static class WellKnownEnvironmentVariables
+{
+    internal const string DirectoryBuildPropertiesPath = "DirectoryBuildPropsPath";
+    internal const string DotNetRollForward = "DOTNET_ROLL_FORWARD";
+    internal const string DotNetRoot = "DOTNET_ROOT";
+    internal const string MSBuildExePath = "MSBUILD_EXE_PATH";
+    internal const string MSBuildExtensionsPath = "MSBuildExtensionsPath";
+    internal const string MSBuildSdksPath = "MSBuildSDKsPath";
+    internal const string NoWarn = "NoWarn";
+    internal const string SkipResolvePackageAssets = "SkipResolvePackageAssets";
+}


### PR DESCRIPTION
Set `DOTNET_ROLL_FORWARD=Major` for `dotnet test` when upgrading to a preview to fix issue that can cause .NET tools to not be able to use the preview version of the runtime if a better version isn't available.

For example, [Microsoft.Extensions.ApiDescription.Server](https://www.nuget.org/packages/Microsoft.Extensions.ApiDescription.Server) for .NET 9 previews only targets `net9.0` and `netcoreapp2.1`, and without roll-forward it tries to use .NET Core 2.1, which isn't really installed anywhere anymore as it is out-of-support.

Found by https://github.com/martincostello/dotnet-bumper/pull/365 after the changes in https://github.com/martincostello/api/pull/1873.
