### PR TITLE
Update Linux distro container labels

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,8 +44,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <AssemblyVersion>0.7.0.0</AssemblyVersion>
-    <VersionPrefix>0.7.4</VersionPrefix>
+    <AssemblyVersion>0.8.0.0</AssemblyVersion>
+    <VersionPrefix>0.8.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' ">
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_HEAD_REF)' == '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>

--- a/src/DotNetBumper.Core/LinuxDistros.cs
+++ b/src/DotNetBumper.Core/LinuxDistros.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Collections.Frozen;
+
+namespace MartinCostello.DotNetBumper;
+
+internal static class LinuxDistros
+{
+    private static readonly FrozenSet<string> UbuntuCodeNames = new[] { "focal", "jammy", "noble" }.ToFrozenSet();
+
+    public static ReadOnlySpan<char> TryUpdateDistro(Version channel, ReadOnlySpan<char> distro)
+    {
+        return channel.Major switch
+        {
+            8 => TryUpdateDistro(distro, ["bookworm"], ["jammy", "noble"], ["19", "20"]),
+            _ => TryUpdateDistro(distro, ["bookworm"], ["noble"], ["20"]), // Latest known versions as of .NET 9
+        };
+
+        static ReadOnlySpan<char> TryUpdateDistro(
+            ReadOnlySpan<char> distro,
+            string[] debian,
+            string[] ubuntu,
+            string[] alpine)
+        {
+            // Is it a Debian image?
+            int index = distro.IndexOf("-slim");
+
+            if (index > -1)
+            {
+                return TryUpgradeDistro(distro, index, debian);
+            }
+
+            // Is it an Alpine 3 image?
+            const string Alpine3 = "alpine3";
+            if (distro.StartsWith(Alpine3) &&
+                distro.Length > (Alpine3.Length + 1) &&
+                distro[Alpine3.Length] is '.')
+            {
+                var maybeVersion = distro[(Alpine3.Length + 1)..];
+
+                if (maybeVersion.Length == 2 || (maybeVersion.Length > 3 && maybeVersion[2] is '-'))
+                {
+                    var suffix = TryUpgradeDistro(maybeVersion, 2, alpine);
+                    return $"{Alpine3}.{suffix}";
+                }
+
+                return distro;
+            }
+
+            // Maybe it's Ubuntu
+            foreach (var codeName in UbuntuCodeNames)
+            {
+                if (distro.StartsWith(codeName, StringComparison.Ordinal))
+                {
+                    return TryUpgradeDistro(distro, codeName.Length, ubuntu);
+                }
+            }
+
+            return distro;
+        }
+
+        static ReadOnlySpan<char> TryUpgradeDistro(ReadOnlySpan<char> distro, int index, string[] candidates)
+        {
+            var name = new string(distro[..index]);
+            var suffix = distro[index..];
+
+            if (candidates.Contains(name, StringComparer.Ordinal))
+            {
+                // Using an existing supported version
+                return distro;
+            }
+
+            // Use the first supported version
+            return $"{candidates[0]}{suffix}";
+        }
+    }
+}

--- a/src/DotNetBumper.Core/Upgraders/DockerfileUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DockerfileUpgrader.cs
@@ -145,7 +145,7 @@ internal sealed partial class DockerfileUpgrader(
 
             if (index is not -1)
             {
-                suffix = maybeVersion[index..];
+                suffix = maybeVersion[(index + 1)..];
                 maybeVersion = maybeVersion[..index];
             }
 
@@ -153,7 +153,7 @@ internal sealed partial class DockerfileUpgrader(
             {
                 builder.Append(channel);
 
-                const string PreviewSuffix = "-preview";
+                const string PreviewSuffix = "preview";
 
                 if (!suffix.IsEmpty)
                 {
@@ -161,6 +161,7 @@ internal sealed partial class DockerfileUpgrader(
                     {
                         if (!suffix.StartsWith(PreviewSuffix, StringComparison.Ordinal))
                         {
+                            builder.Append('-');
                             builder.Append(PreviewSuffix);
                         }
                     }
@@ -169,10 +170,17 @@ internal sealed partial class DockerfileUpgrader(
                         suffix = suffix[PreviewSuffix.Length..];
                     }
 
+                    if (suffix.Length > 0)
+                    {
+                        builder.Append('-');
+                        suffix = LinuxDistros.TryUpdateDistro(channel, suffix);
+                    }
+
                     builder.Append(suffix);
                 }
                 else if (supportPhase == DotNetSupportPhase.Preview)
                 {
+                    builder.Append('-');
                     builder.Append(PreviewSuffix);
                 }
 

--- a/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
@@ -182,26 +182,28 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
             testCases.Add("FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk AS build", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build");
             testCases.Add("From --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk As build", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk As build");
             testCases.Add("from --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk as build", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk as build");
+
+            // With specific labels
+            testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-ltsc2022", channel, type, true, $"FROM mcr.microsoft.com/dotnet/sdk:{channel}{suffix}-nanoserver-ltsc2022");
+            testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-1809", channel, type, true, $"FROM mcr.microsoft.com/dotnet/sdk:{channel}{suffix}-nanoserver-1809");
+            testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2019", channel, type, true, $"FROM mcr.microsoft.com/dotnet/sdk:{channel}{suffix}-windowsservercore-ltsc2019");
+            testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022", channel, type, true, $"FROM mcr.microsoft.com/dotnet/sdk:{channel}{suffix}-windowsservercore-ltsc2022");
         }
 
-        // TODO:
-        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-ltsc2022
-        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-1809
-        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2019
-        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022
-        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner
-        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0
-        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0
-        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner
-        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-ltsc2022
-        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-1809
-        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-windowsservercore-ltsc2019
-        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-windowsservercore-ltsc2022
-        // docker pull mcr.microsoft.com/dotnet/sdk:9.0-azurelinux3.0
-        // docker pull mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2022
-        // docker pull mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-1809
-        // docker pull mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2019
-        // docker pull mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2022
+        // Mariner/Azure Linux 3.0
+        testCases.Add("FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-cbl-mariner", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-cbl-mariner");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-cbl-mariner2.0", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-cbl-mariner2.0");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-cbl-mariner2.0-distroless", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-cbl-mariner2.0-distroless");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-cbl-mariner", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-cbl-mariner");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-cbl-mariner2.0", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-cbl-mariner2.0");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-cbl-mariner2.0-distroless", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-cbl-mariner2.0-distroless");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-cbl-mariner", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-azurelinux3.0");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-cbl-mariner2.0", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-azurelinux3.0");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-cbl-mariner2.0-distroless", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-azurelinux3.0-distroless");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-azurelinux3.0", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-azurelinux3.0");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-azurelinux3.0-distroless", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-azurelinux3.0-distroless");
 
         // With specific Alpine 3 labels
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet-sdk");

--- a/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
@@ -123,27 +123,27 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
             testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel}", channel, type, false, null);
             testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel}-preview", channel, type, false, null);
             testCases.Add($"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk", channel, type, false, null);
-            testCases.Add($"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra", channel, type, false, null);
+            testCases.Add($"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-alpine-extra", channel, type, false, null);
 
             // With name
             testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel} AS build", channel, type, false, null);
             testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel} AS build-env", channel, type, false, null);
             testCases.Add($"FROM mcr.microsoft.com/dotnet/aspnet:{channel}-preview AS build", channel, type, false, null);
             testCases.Add($"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build", channel, type, false, null);
-            testCases.Add($"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra AS final", channel, type, false, null);
+            testCases.Add($"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-alpine-extra AS final", channel, type, false, null);
 
             // With platform
             testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}", channel, type, false, null);
             testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}-preview", channel, type, false, null);
             testCases.Add($"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk", channel, type, false, null);
-            testCases.Add($"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra", channel, type, false, null);
+            testCases.Add($"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-alpine-extra", channel, type, false, null);
 
             // With platform and name
             testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel} AS build", channel, type, false, null);
             testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel} AS build-env", channel, type, false, null);
             testCases.Add($"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}-preview AS build", channel, type, false, null);
             testCases.Add($"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build", channel, type, false, null);
-            testCases.Add($"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-jammy-chiseled-extra AS final", channel, type, false, null);
+            testCases.Add($"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}-alpine-extra AS final", channel, type, false, null);
         }
 
         foreach ((var channel, var type) in channels)
@@ -152,7 +152,7 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
 
             testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0", channel, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
             testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0-preview", channel, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
-            testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra", channel, type, true, $"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra");
+            testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-alpine-extra", channel, type, true, $"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-alpine-extra");
             testCases.Add("FROM docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
             testCases.Add("From docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
             testCases.Add("from docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
@@ -161,7 +161,7 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
             testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS build", channel, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
             testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS build-env", channel, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build-env");
             testCases.Add("FROM mcr.microsoft.com/dotnet/aspnet:6.0-preview AS build", channel, type, true, $"FROM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
-            testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra AS final", channel, type, true, $"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra AS final");
+            testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-alpine-extra AS final", channel, type, true, $"FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-alpine-extra AS final");
             testCases.Add("FROM docker.custom-domain.com/base-images/dotnet-6.0-sdk AS build", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build");
             testCases.Add("From docker.custom-domain.com/base-images/dotnet-6.0-sdk As build", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk As build");
             testCases.Add("from docker.custom-domain.com/base-images/dotnet-6.0-sdk as build", channel, type, true, $"FROM docker.custom-domain.com/base-images/dotnet-{channel}-sdk as build");
@@ -169,7 +169,7 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
             // With platform
             testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0", channel, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
             testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0-preview", channel, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix}");
-            testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra");
+            testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-alpine-extra", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-alpine-extra");
             testCases.Add("FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
             testCases.Add("From --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
             testCases.Add("from --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk");
@@ -178,11 +178,167 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
             testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0 AS build", channel, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
             testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0-preview AS build", channel, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build");
             testCases.Add("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0-preview AS build-env", channel, type, true, $"FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:{channel}{suffix} AS build-env");
-            testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra AS final", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-jammy-chiseled-extra AS final");
+            testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-alpine-extra AS final", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:{channel}{suffix}-alpine-extra AS final");
             testCases.Add("FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk AS build", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk AS build");
             testCases.Add("From --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk As build", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk As build");
             testCases.Add("from --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-6.0-sdk as build", channel, type, true, $"FROM --platform=$BUILDPLATFORM docker.custom-domain.com/base-images/dotnet-{channel}-sdk as build");
         }
+
+        // TODO:
+        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-ltsc2022
+        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-1809
+        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2019
+        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022
+        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner
+        // docker pull mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0
+        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0
+        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner
+        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-ltsc2022
+        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-1809
+        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-windowsservercore-ltsc2019
+        // docker pull mcr.microsoft.com/dotnet/sdk:8.0-windowsservercore-ltsc2022
+        // docker pull mcr.microsoft.com/dotnet/sdk:9.0-azurelinux3.0
+        // docker pull mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2022
+        // docker pull mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-1809
+        // docker pull mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2019
+        // docker pull mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2022
+
+        // With specific Alpine 3 labels
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.13 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.14 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.15 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.16 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.18 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.19 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.20 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20 AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.13 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.14 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.13 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.14 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.13 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.14 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.15 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.16 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.17 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.18 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.19 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+
+        // With specific Debian labels
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS dotnet-sdk");
+
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-bookworm-slim AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-bookworm-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-bookworm-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-bookworm-slim AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS dotnet-sdk");
+
+        // With specific Ubuntu labels
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-noble AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-noble AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS dotnet-sdk");
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-noble AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS dotnet-sdk");
+
+        testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra", "8.0", DotNetSupportPhase.Active, true, "FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra");
+        testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra", "9.0", DotNetSupportPhase.Active, true, "FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:9.0-noble-chiseled-extra");
+        testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra", "9.0", DotNetSupportPhase.Active, true, "FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:9.0-noble-chiseled-extra");
+        testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:8.0-noble-chiseled-extra", "9.0", DotNetSupportPhase.Active, true, "FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:9.0-noble-chiseled-extra");
+
+        testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra AS final", "8.0", DotNetSupportPhase.Active, true, "FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra AS final");
+        testCases.Add("FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra AS final", "9.0", DotNetSupportPhase.Active, true, "FROM docker-virtual.custom-domain.com/dotnet/runtime-deps:9.0-noble-chiseled-extra AS final");
+        testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra", "8.0", DotNetSupportPhase.Active, true, "FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra");
+        testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra", "9.0", DotNetSupportPhase.Active, true, "FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:9.0-noble-chiseled-extra");
+        testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra AS final", "8.0", DotNetSupportPhase.Active, true, "FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:8.0-jammy-chiseled-extra AS final");
+        testCases.Add("FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:6.0-jammy-chiseled-extra AS final", "9.0", DotNetSupportPhase.Active, true, "FROM --platform=$BUILDPLATFORM docker-virtual.custom-domain.com/dotnet/runtime-deps:9.0-noble-chiseled-extra AS final");
 
         return testCases;
     }

--- a/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
@@ -207,87 +207,52 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
 
         // With specific Alpine 3 labels
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.13 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.14 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.15 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.16 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.18 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.19 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.20 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20 AS dotnet-sdk");
-
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.13 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.14 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.13 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.14 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.13 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.14 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.15 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.16 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.17 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.18 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.19 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
-
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.15 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.16 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.17 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
-
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.GoLive, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.18 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
-        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20 AS dotnet-sdk", "9.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+
+        // Upgrades for .NET versions with an Alpine version that is no longer supported
+        foreach (int minor in Enumerable.Range(13, 7))
+        {
+            testCases.Add($"FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.{minor} AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+            testCases.Add($"FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.{minor} AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+
+            foreach (var supportPhase in new[] { DotNetSupportPhase.GoLive, DotNetSupportPhase.Active })
+            {
+                testCases.Add($"FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.{minor} AS dotnet-sdk", "9.0", supportPhase, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+            }
+        }
+
+        foreach (int minor in Enumerable.Range(15, 5))
+        {
+            testCases.Add($"FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.{minor} AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19 AS dotnet-sdk");
+            testCases.Add($"FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.{minor} AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+
+            foreach (var supportPhase in new[] { DotNetSupportPhase.GoLive, DotNetSupportPhase.Active })
+            {
+                testCases.Add($"FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.{minor} AS dotnet-sdk", "9.0", supportPhase, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+            }
+        }
+
+        foreach (int minor in Enumerable.Range(18, 3))
+        {
+            testCases.Add($"FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.{minor} AS dotnet-sdk", "9.0", DotNetSupportPhase.Preview, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine3.20 AS dotnet-sdk");
+
+            foreach (var supportPhase in new[] { DotNetSupportPhase.GoLive, DotNetSupportPhase.Active })
+            {
+                testCases.Add($"FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.{minor} AS dotnet-sdk", "9.0", supportPhase, true, "FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20 AS dotnet-sdk");
+            }
+        }
+
+        // Upgrades for .NET versions with an Alpine version that is still supported
+        testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.20 AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20 AS dotnet-sdk");
 
         // With specific Debian labels
         testCases.Add("FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS dotnet-sdk", "8.0", DotNetSupportPhase.Active, true, "FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS dotnet-sdk");


### PR DESCRIPTION
- When upgrading the image for a Dockerfile, update the label for an appropriate valid version if specific versions are used.
- For .NET 9+, upgrade Mariner 2 labels to Azure Linux 3.
- Bump version to 0.8.0.

Resolves #381.
