### PR TITLE
Disable NuGet Audit

### DIFF
--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -177,6 +177,7 @@ internal sealed partial class DotNetTestPostProcessor(
         var environmentVariables = new Dictionary<string, string?>()
         {
             [BumperTestLogger.LoggerDirectoryPathVariableName] = logsDirectory.Path,
+            [WellKnownEnvironmentVariables.NuGetAudit] = "false",
         };
 
         if (sdkVersion.IsPrerelease)

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -207,9 +207,10 @@ internal sealed partial class PackageVersionUpgrader(
             arguments.Add(package);
         }
 
-        var environmentVariables = new Dictionary<string, string?>(2)
+        var environmentVariables = new Dictionary<string, string?>(3)
         {
             [WellKnownEnvironmentVariables.DotNetRollForward] = "Major",
+            [WellKnownEnvironmentVariables.NuGetAudit] = "false",
         };
 
         MSBuildHelper.TryAddSdkProperties(environmentVariables, sdkVersion.ToString());

--- a/src/DotNetBumper.Core/WellKnownEnvironmentVariables.cs
+++ b/src/DotNetBumper.Core/WellKnownEnvironmentVariables.cs
@@ -16,5 +16,6 @@ internal static class WellKnownEnvironmentVariables
     internal const string MSBuildExtensionsPath = "MSBuildExtensionsPath";
     internal const string MSBuildSdksPath = "MSBuildSDKsPath";
     internal const string NoWarn = "NoWarn";
+    internal const string NuGetAudit = "NuGetAudit";
     internal const string SkipResolvePackageAssets = "SkipResolvePackageAssets";
 }


### PR DESCRIPTION
Explicitly disable NuGet audit during upgrades to avoid failures due to existing transient dependencies in the dependency graph when upgrading to .NET 9+.
