### PR TITLE
Fix Dockerfiles being corrupted

### DIFF
--- a/src/DotNetBumper.Core/Upgraders/DockerfileUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DockerfileUpgrader.cs
@@ -375,7 +375,7 @@ internal sealed partial class DockerfileUpgrader(
             await buffered.CopyToAsync(output, cancellationToken);
             await buffered.FlushAsync(cancellationToken);
 
-            buffered.SetLength(buffered.Position);
+            output.SetLength(buffered.Position);
 
             if (portsUpdated)
             {

--- a/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
@@ -337,7 +337,7 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
         // Arrange
         string fileContents =
             """
-            FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+            FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS build-env
             WORKDIR /App
 
             COPY . ./


### PR DESCRIPTION
If the content of a Dockerfile shrinks, it could become corrupted with leftover content as the wrong stream's length was being set.
