### PR TITLE
Update RID data

### DIFF
--- a/src/DotNetBumper.Core/Resources/runtime-identifiers.json
+++ b/src/DotNetBumper.Core/Resources/runtime-identifiers.json
@@ -2135,6 +2135,12 @@
         "linux-riscv64"
       ]
     },
+    "linux-musl-loongarch64": {
+      "#import": [
+        "linux-musl",
+        "linux-loongarch64"
+      ]
+    },
     "linux-musl-s390x": {
       "#import": [
         "linux-musl",

--- a/src/DotNetBumper.Core/Resources/runtime-identifiers.portable.json
+++ b/src/DotNetBumper.Core/Resources/runtime-identifiers.portable.json
@@ -249,6 +249,12 @@
         "linux-riscv64"
       ]
     },
+    "linux-musl-loongarch64": {
+      "#import": [
+        "linux-musl",
+        "linux-loongarch64"
+      ]
+    },
     "linux-musl-s390x": {
       "#import": [
         "linux-musl",

--- a/src/DotNetBumper.Core/RuntimeIdentifier.cs
+++ b/src/DotNetBumper.Core/RuntimeIdentifier.cs
@@ -11,8 +11,14 @@ namespace MartinCostello.DotNetBumper;
 
 internal sealed partial record RuntimeIdentifier(string Value)
 {
+    /// <summary>
+    /// See https://github.com/dotnet/runtime/blob/49006967613007f58daab31abab5316999aa7897/src/libraries/Microsoft.NETCore.Platforms/src/PortableRuntimeIdentifierGraph.json.
+    /// </summary>
     private static readonly ImmutableDictionary<string, ImmutableHashSet<string>> PortableRids = LoadRuntimeIds("runtime-identifiers.portable");
 
+    /// <summary>
+    /// See https://github.com/dotnet/runtime/blob/49006967613007f58daab31abab5316999aa7897/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json.
+    /// </summary>
     private static readonly ImmutableDictionary<string, ImmutableHashSet<string>> NonPortableRids = LoadRuntimeIds("runtime-identifiers");
 
     public bool IsPortable => PortableRids.ContainsKey(Value);


### PR DESCRIPTION
Update runtime identifier data.

Taken from [here](https://github.com/dotnet/runtime/tree/49006967613007f58daab31abab5316999aa7897/src/libraries/Microsoft.NETCore.Platforms/src).
