### PR TITLE
Remove Microsoft.Build group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,6 @@ updates:
 - package-ecosystem: nuget
   directory: "/"
   groups:
-    Microsoft.Build:
-      patterns:
-        - Microsoft.Build
-        - Microsoft.Build.Utilities.Core
     Spectre:
       patterns:
         - Spectre.Console*


### PR DESCRIPTION
Dependabot doesn't support ignore-by-close for groups or the multi-targeting needed, so remove the group so get notified of new versions and can then manually fix-up.
