### PR TITLE
Prepare for xunit v3 and Fix Finding dotnet On Ubuntu 24.04

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,7 +33,6 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Management.Automation" Version="7.4.6" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-    <PackageVersion Include="xRetry" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />

--- a/src/DotNetBumper.Core/DotNetBumper.Core.csproj
+++ b/src/DotNetBumper.Core/DotNetBumper.Core.csproj
@@ -16,7 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ignore" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -85,6 +85,17 @@ internal sealed partial class DotNetTestPostProcessor(
                     Console.WriteProgressLine(TaskEnvironment, result.StandardOutput);
                 }
 
+                if (Logger.IsEnabled(LogLevel.Debug) && result.TestLogs?.Outcomes is { } outcomes)
+                {
+                    foreach ((string container, var tests) in outcomes)
+                    {
+                        foreach (var test in tests.Where((p) => p.Outcome is "Failed"))
+                        {
+                            Log.TestFailed(Logger, container, test.Id, test.ErrorMessage);
+                        }
+                    }
+                }
+
                 if (result.BuildLogs?.Summary?.Count > 0)
                 {
                     WriteBuildLogs(result.BuildLogs.Summary);
@@ -432,5 +443,11 @@ internal sealed partial class DotNetTestPostProcessor(
             Level = LogLevel.Debug,
             Message = "Failed to evaluate the value of the {PropertyName} MSBuild property from {ProjectFile}.")]
         public static partial void FailedToEvaluateProperty(ILogger logger, string propertyName, string projectFile, Exception exception);
+
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Debug,
+            Message = "Test {Container}.{Id} failed: {ErrorMessage}")]
+        public static partial void TestFailed(ILogger logger, string container, string? id, string? errorMessage);
     }
 }

--- a/src/DotNetBumper/DotNetBumper.csproj
+++ b/src/DotNetBumper/DotNetBumper.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\DotNetBumper.Core\DotNetBumper.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />

--- a/tests/DotNetBumper.Tests/BumperConfigurationLoaderTests.cs
+++ b/tests/DotNetBumper.Tests/BumperConfigurationLoaderTests.cs
@@ -16,7 +16,7 @@ public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        var actual = await target.LoadAsync(CancellationToken.None);
+        var actual = await target.LoadAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldBeNull();
@@ -38,7 +38,7 @@ public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture, options);
 
         // Act and Assert
-        await Should.ThrowAsync<FileNotFoundException>(() => target.LoadAsync(CancellationToken.None));
+        await Should.ThrowAsync<FileNotFoundException>(() => target.LoadAsync(fixture.CancellationToken));
     }
 
     [Theory]
@@ -64,7 +64,7 @@ public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture, options);
 
         // Act and Assert
-        await Should.ThrowAsync<InvalidOperationException>(() => target.LoadAsync(CancellationToken.None));
+        await Should.ThrowAsync<InvalidOperationException>(() => target.LoadAsync(fixture.CancellationToken));
     }
 
     [Theory]
@@ -88,7 +88,7 @@ public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture, options);
 
         // Act
-        var actual = await target.LoadAsync(CancellationToken.None);
+        var actual = await target.LoadAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -105,7 +105,7 @@ public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        var actual = await target.LoadAsync(CancellationToken.None);
+        var actual = await target.LoadAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -127,7 +127,7 @@ public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        var actual = await target.LoadAsync(CancellationToken.None);
+        var actual = await target.LoadAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -149,7 +149,7 @@ public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        var actual = await target.LoadAsync(CancellationToken.None);
+        var actual = await target.LoadAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -167,12 +167,12 @@ public class BumperConfigurationLoaderTests(ITestOutputHelper outputHelper)
         // Arrange
         using var fixture = new UpgraderFixture(outputHelper);
 
-        await File.WriteAllTextAsync(Path.Combine(fixture.Project.DirectoryName, fileName), content);
+        await File.WriteAllTextAsync(Path.Combine(fixture.Project.DirectoryName, fileName), content, fixture.CancellationToken);
 
         var target = CreateTarget(fixture);
 
         // Act
-        var actual = await target.LoadAsync(CancellationToken.None);
+        var actual = await target.LoadAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldBeNull();

--- a/tests/DotNetBumper.Tests/BumperConfigurationProviderTests.cs
+++ b/tests/DotNetBumper.Tests/BumperConfigurationProviderTests.cs
@@ -16,7 +16,7 @@ public class BumperConfigurationProviderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture, upgradeType);
 
         // Act
-        var actual = await target.GetAsync(CancellationToken.None);
+        var actual = await target.GetAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -35,7 +35,7 @@ public class BumperConfigurationProviderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture, UpgradeType.Preview);
 
         // Act
-        var actual = await target.GetAsync(CancellationToken.None);
+        var actual = await target.GetAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -55,7 +55,7 @@ public class BumperConfigurationProviderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture, UpgradeType.Preview);
 
         // Act
-        var actual = await target.GetAsync(CancellationToken.None);
+        var actual = await target.GetAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -75,7 +75,7 @@ public class BumperConfigurationProviderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture, UpgradeType.Preview);
 
         // Act
-        var actual = await target.GetAsync(CancellationToken.None);
+        var actual = await target.GetAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();

--- a/tests/DotNetBumper.Tests/DotNetBumper.Tests.csproj
+++ b/tests/DotNetBumper.Tests/DotNetBumper.Tests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Spectre.Console.Testing" />
     <PackageReference Include="System.Linq.Async" />
-    <PackageReference Include="xRetry" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Xunit.SkippableFact" />

--- a/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
@@ -22,7 +22,7 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
 #pragma warning restore IDE0028
     }
 
-    [xRetry.RetryTheory]
+    [Theory]
     [MemberData(nameof(Channels))]
     public async Task PostProcessAsync_Succeeds_When_No_DirectoryBuildProps(string channel)
     {
@@ -42,7 +42,7 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
         actual.ShouldBe(ProcessingResult.Success);
     }
 
-    [xRetry.RetryTheory]
+    [Theory]
     [MemberData(nameof(Channels))]
     public async Task PostProcessAsync_Succeeds_When_DirectoryBuildProps_Without_ArtifactsOutput(string channel)
     {
@@ -64,7 +64,7 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
         actual.ShouldBe(ProcessingResult.Success);
     }
 
-    [xRetry.RetryTheory]
+    [Theory]
     [InlineData("8.0", "", "")]
     [InlineData("8.0", "false", "")]
     [InlineData("8.0", "true", "")]

--- a/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/LeftoverReferencesPostProcessorTests.cs
@@ -49,7 +49,7 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
         var projectFile = new ProjectFile(fullPath, relativePath);
 
         // Act
-        var actual = await LeftoverReferencesPostProcessor.FindReferencesAsync(projectFile, channel, CancellationToken.None);
+        var actual = await LeftoverReferencesPostProcessor.FindReferencesAsync(projectFile, channel, fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -74,7 +74,7 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
         projectFile = new ProjectFile(fullPath, relativePath);
 
         // Act
-        actual = await LeftoverReferencesPostProcessor.FindReferencesAsync(projectFile, channel, CancellationToken.None);
+        actual = await LeftoverReferencesPostProcessor.FindReferencesAsync(projectFile, channel, fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -94,7 +94,9 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
         var target = CreateTarget(fixture);
 
         // Act
-        var actual = await target.EnumerateProjectFilesAsync(CancellationToken.None).ToListAsync();
+        var actual = await target
+            .EnumerateProjectFilesAsync(fixture.CancellationToken)
+            .ToListAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -115,7 +117,9 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
         var target = CreateTarget(fixture);
 
         // Act
-        var actual = await target.EnumerateProjectFilesAsync(CancellationToken.None).ToListAsync();
+        var actual = await target
+            .EnumerateProjectFilesAsync(fixture.CancellationToken)
+            .ToListAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -160,7 +164,9 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
         var target = CreateTarget(fixture);
 
         // Act
-        var actual = await target.EnumerateProjectFilesAsync(CancellationToken.None).ToListAsync();
+        var actual = await target
+            .EnumerateProjectFilesAsync(fixture.CancellationToken)
+            .ToListAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -201,7 +207,7 @@ public class LeftoverReferencesPostProcessorTests(ITestOutputHelper outputHelper
         };
 
         // Act
-        var actual = await target.PostProcessAsync(upgrade, CancellationToken.None);
+        var actual = await target.PostProcessAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.Success);

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -305,6 +305,7 @@ internal sealed class Project : IDisposable
             .Property("EnableNETAnalyzers", true)
             .Property("EnforceCodeStyleInBuild", true)
             .Property("GenerateDocumentationFile", true)
+            .Property("LangVersion", "latest")
             .Property("NoWarn", $"$(NoWarn);{noWarn ?? "CA1002;CA1819;CS419;CS1570;CS1573;CS1574;CS1584;CS1591"}")
             .Property("TreatWarningsAsErrors", treatWarningsAsErrors);
 

--- a/tests/DotNetBumper.Tests/ProjectUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/ProjectUpgraderTests.cs
@@ -19,7 +19,7 @@ public class ProjectUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        int actual = await target.UpgradeAsync(CancellationToken.None);
+        int actual = await target.UpgradeAsync(fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(0);

--- a/tests/DotNetBumper.Tests/UpgraderFixture.cs
+++ b/tests/DotNetBumper.Tests/UpgraderFixture.cs
@@ -18,6 +18,8 @@ internal sealed class UpgraderFixture(
     private readonly TestConsole _console = new();
     private readonly Project _project = new();
 
+    public CancellationToken CancellationToken { get; } = CancellationToken.None;
+
     public IAnsiConsole Console => _console;
 
     public IEnvironment Environment => environment ??= CreateEnvironment();

--- a/tests/DotNetBumper.Tests/Upgraders/AwsLambdaToolsUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/AwsLambdaToolsUpgraderTests.cs
@@ -45,12 +45,12 @@ public class AwsLambdaToolsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(lambdaDefaultsFile);
+        string actualContent = await File.ReadAllTextAsync(lambdaDefaultsFile, fixture.CancellationToken);
 
         var defaults = JsonDocument.Parse(actualContent);
         defaults.RootElement.ValueKind.ShouldBe(JsonValueKind.Object);
@@ -64,7 +64,7 @@ public class AwsLambdaToolsUpgraderTests(ITestOutputHelper outputHelper)
         runtime.GetString().ShouldBe($"dotnet{upgrade.Channel.Major}");
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -117,12 +117,12 @@ public class AwsLambdaToolsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Warning);
 
-        string actualContent = await File.ReadAllTextAsync(lambdaDefaultsFile);
+        string actualContent = await File.ReadAllTextAsync(lambdaDefaultsFile, fixture.CancellationToken);
         actualContent.NormalizeLineEndings().Trim().ShouldBe(fileContents.NormalizeLineEndings().Trim());
     }
 
@@ -161,7 +161,7 @@ public class AwsLambdaToolsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(expected);
@@ -206,15 +206,15 @@ public class AwsLambdaToolsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(jsonFile);
+        string actualContent = await File.ReadAllTextAsync(jsonFile, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(jsonFile);
+        byte[] actualBytes = await File.ReadAllBytesAsync(jsonFile, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -226,7 +226,7 @@ public class AwsLambdaToolsUpgraderTests(ITestOutputHelper outputHelper)
         }
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);

--- a/tests/DotNetBumper.Tests/Upgraders/AwsSamTemplateUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/AwsSamTemplateUpgraderTests.cs
@@ -123,12 +123,12 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(templateFile);
+        string actualContent = await File.ReadAllTextAsync(templateFile, fixture.CancellationToken);
 
         var samTemplate = JsonDocument.Parse(actualContent);
         samTemplate.RootElement.ValueKind.ShouldBe(JsonValueKind.Object);
@@ -147,7 +147,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         node.GetString().ShouldBe($"dotnet{upgrade.Channel.Major}");
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -176,19 +176,19 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(templateFile);
+        string actualContent = await File.ReadAllTextAsync(templateFile, fixture.CancellationToken);
 
         actualContent.Split(Environment.NewLine)
                      .Count((p) => p.Contains($"dotnet{upgrade.Channel.Major}", StringComparison.Ordinal))
                      .ShouldBe(2);
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -228,12 +228,12 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Warning);
 
-        string actualContent = await File.ReadAllTextAsync(templateFile);
+        string actualContent = await File.ReadAllTextAsync(templateFile, fixture.CancellationToken);
         actualContent.NormalizeLineEndings().Trim().ShouldBe(template.NormalizeLineEndings().Trim());
     }
 
@@ -265,12 +265,12 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Warning);
 
-        string actualContent = await File.ReadAllTextAsync(templateFile);
+        string actualContent = await File.ReadAllTextAsync(templateFile, fixture.CancellationToken);
         actualContent.NormalizeLineEndings().Trim().ShouldBe(template.NormalizeLineEndings().Trim());
     }
 
@@ -302,7 +302,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -336,7 +336,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -376,7 +376,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -409,7 +409,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -458,7 +458,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -500,7 +500,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -528,7 +528,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -578,7 +578,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -618,7 +618,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -676,15 +676,15 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(jsonFile);
+        string actualContent = await File.ReadAllTextAsync(jsonFile, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(jsonFile);
+        byte[] actualBytes = await File.ReadAllBytesAsync(jsonFile, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -696,7 +696,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         }
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -765,15 +765,15 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(jsonFile);
+        string actualContent = await File.ReadAllTextAsync(jsonFile, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(jsonFile);
+        byte[] actualBytes = await File.ReadAllBytesAsync(jsonFile, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -785,7 +785,7 @@ public class AwsSamTemplateUpgraderTests(ITestOutputHelper outputHelper)
         }
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);

--- a/tests/DotNetBumper.Tests/Upgraders/ContainerBaseImageUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/ContainerBaseImageUpgraderTests.cs
@@ -32,7 +32,7 @@ public class ContainerBaseImageUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
@@ -52,7 +52,7 @@ public class ContainerBaseImageUpgraderTests(ITestOutputHelper outputHelper)
         actualValue.ShouldBe($"mcr.microsoft.com/dotnet/nightly/runtime-deps:{channel}-noble-chiseled-extra");
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);

--- a/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DockerfileUpgraderTests.cs
@@ -381,16 +381,16 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(dockerfile);
+        string actualContent = await File.ReadAllTextAsync(dockerfile, fixture.CancellationToken);
         actualContent.TrimEnd().ShouldBe(expectedContents.TrimEnd());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -476,16 +476,16 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(dockerfile);
+        string actualContent = await File.ReadAllTextAsync(dockerfile, fixture.CancellationToken);
         actualContent.TrimEnd().ShouldBe(expectedContents.TrimEnd());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -517,7 +517,7 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -580,15 +580,15 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(dockerfile);
+        string actualContent = await File.ReadAllTextAsync(dockerfile, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(dockerfile);
+        byte[] actualBytes = await File.ReadAllBytesAsync(dockerfile, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -600,7 +600,7 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
         }
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -687,18 +687,18 @@ public class DockerfileUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(expectedResult);
 
         fixture.LogContext.Changelog.Add("Update exposed Docker container ports");
 
-        string actualContent = await File.ReadAllTextAsync(dockerfile);
+        string actualContent = await File.ReadAllTextAsync(dockerfile, fixture.CancellationToken);
         actualContent.TrimEnd().ShouldBe(expectedContents.TrimEnd());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);

--- a/tests/DotNetBumper.Tests/Upgraders/GitHubActionsUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/GitHubActionsUpgraderTests.cs
@@ -68,16 +68,16 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(workflow);
+        string actualContent = await File.ReadAllTextAsync(workflow, fixture.CancellationToken);
         actualContent.TrimEnd().ShouldBe(expectedContents.TrimEnd());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -165,16 +165,16 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(workflow);
+        string actualContent = await File.ReadAllTextAsync(workflow, fixture.CancellationToken);
         actualContent.TrimEnd().ShouldBe(expectedContents.TrimEnd());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -272,16 +272,16 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(workflow);
+        string actualContent = await File.ReadAllTextAsync(workflow, fixture.CancellationToken);
         actualContent.TrimEnd().ShouldBe(expectedContents.TrimEnd());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -377,16 +377,16 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(workflow);
+        string actualContent = await File.ReadAllTextAsync(workflow, fixture.CancellationToken);
         actualContent.TrimEnd().ShouldBe(expectedContents.TrimEnd());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -512,16 +512,16 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(workflow);
+        string actualContent = await File.ReadAllTextAsync(workflow, fixture.CancellationToken);
         actualContent.TrimEnd().ShouldBe(expectedContents.TrimEnd());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -621,16 +621,16 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(workflow);
+        string actualContent = await File.ReadAllTextAsync(workflow, fixture.CancellationToken);
         actualContent.TrimEnd().ShouldBe(expectedContents.TrimEnd());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -669,7 +669,7 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -719,7 +719,7 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -751,7 +751,7 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -802,7 +802,7 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -863,15 +863,15 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(workflow);
+        string actualContent = await File.ReadAllTextAsync(workflow, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(workflow);
+        byte[] actualBytes = await File.ReadAllBytesAsync(workflow, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -883,7 +883,7 @@ public class GitHubActionsUpgraderTests(ITestOutputHelper outputHelper)
         }
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);

--- a/tests/DotNetBumper.Tests/Upgraders/GlobalJsonUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/GlobalJsonUpgraderTests.cs
@@ -54,17 +54,17 @@ public class GlobalJsonUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
         fixture.LogContext.Changelog.ShouldContain($"Update .NET SDK to `{upgrade.SdkVersion}`");
 
-        string actualContent = await File.ReadAllTextAsync(globalJson);
+        string actualContent = await File.ReadAllTextAsync(globalJson, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(globalJson);
+        byte[] actualBytes = await File.ReadAllBytesAsync(globalJson, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -76,7 +76,7 @@ public class GlobalJsonUpgraderTests(ITestOutputHelper outputHelper)
         }
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -113,7 +113,7 @@ public class GlobalJsonUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.Warning);

--- a/tests/DotNetBumper.Tests/Upgraders/PowerShellScriptUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/PowerShellScriptUpgraderTests.cs
@@ -303,7 +303,7 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -444,7 +444,7 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -473,7 +473,7 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -518,15 +518,15 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(script);
+        string actualContent = await File.ReadAllTextAsync(script, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(script);
+        byte[] actualBytes = await File.ReadAllBytesAsync(script, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -538,7 +538,7 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
         }
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -736,7 +736,7 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
@@ -745,7 +745,7 @@ public class PowerShellScriptUpgraderTests(ITestOutputHelper outputHelper)
         actualContent.TrimEnd().ShouldBe(expectedContents.TrimEnd());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);

--- a/tests/DotNetBumper.Tests/Upgraders/RuntimeIdentifierUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/RuntimeIdentifierUpgraderTests.cs
@@ -76,7 +76,7 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
@@ -86,7 +86,7 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
             var bom = Encoding.UTF8.GetPreamble();
             var buffer = new byte[bom.Length];
 
-            await stream.ReadExactlyAsync(buffer, 0, buffer.Length);
+            await stream.ReadExactlyAsync(buffer, 0, buffer.Length, fixture.CancellationToken);
 
             bom.Length.ShouldBeGreaterThan(0);
             bom.SequenceEqual(buffer).ShouldBe(hasByteOrderMark);
@@ -107,7 +107,7 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
         actualValue.ShouldBe(expectedValue);
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -173,16 +173,16 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(pubxml);
+        string actualContent = await File.ReadAllTextAsync(pubxml, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -246,16 +246,16 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(pubxml);
+        string actualContent = await File.ReadAllTextAsync(pubxml, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -290,7 +290,7 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(expected);
@@ -341,15 +341,15 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(properties);
+        string actualContent = await File.ReadAllTextAsync(properties, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(properties);
+        byte[] actualBytes = await File.ReadAllBytesAsync(properties, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -361,7 +361,7 @@ public class RuntimeIdentifierUpgraderTests(ITestOutputHelper outputHelper)
         }
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);

--- a/tests/DotNetBumper.Tests/Upgraders/ServerlessUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/ServerlessUpgraderTests.cs
@@ -54,7 +54,7 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
@@ -86,12 +86,12 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
             "    runtime: dotnet8 # This is another comment",
             "    timeout: 10") + Environment.NewLine;
 
-        string actualContent = await File.ReadAllTextAsync(serverlessFile);
+        string actualContent = await File.ReadAllTextAsync(serverlessFile, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
         fixture.LogContext.Changelog.ShouldNotBeEmpty();
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -128,7 +128,7 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -174,7 +174,7 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(expected);
@@ -205,7 +205,7 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.Warning);
@@ -253,15 +253,15 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(serverlessFile);
+        string actualContent = await File.ReadAllTextAsync(serverlessFile, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(serverlessFile);
+        byte[] actualBytes = await File.ReadAllBytesAsync(serverlessFile, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -275,7 +275,7 @@ public class ServerlessUpgraderTests(ITestOutputHelper outputHelper)
         fixture.LogContext.Changelog.ShouldContain($"Update AWS Lambda runtime to `dotnet{upgrade.Channel.Major}`");
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);

--- a/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/TargetFrameworkUpgraderTests.cs
@@ -78,7 +78,7 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
@@ -88,7 +88,7 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
             var bom = Encoding.UTF8.GetPreamble();
             var buffer = new byte[bom.Length];
 
-            await stream.ReadExactlyAsync(buffer, 0, buffer.Length);
+            await stream.ReadExactlyAsync(buffer, 0, buffer.Length, fixture.CancellationToken);
 
             bom.Length.ShouldBeGreaterThan(0);
             bom.SequenceEqual(buffer).ShouldBe(hasByteOrderMark);
@@ -109,7 +109,7 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
         actualValue.ShouldBe(expectedValue);
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -175,16 +175,16 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(pubxml);
+        string actualContent = await File.ReadAllTextAsync(pubxml, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -248,16 +248,16 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(pubxml);
+        string actualContent = await File.ReadAllTextAsync(pubxml, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -292,7 +292,7 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(expected);
@@ -343,15 +343,15 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(properties);
+        string actualContent = await File.ReadAllTextAsync(properties, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(properties);
+        byte[] actualBytes = await File.ReadAllBytesAsync(properties, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -363,7 +363,7 @@ public class TargetFrameworkUpgraderTests(ITestOutputHelper outputHelper)
         }
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);

--- a/tests/DotNetBumper.Tests/Upgraders/VisualStudioCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/VisualStudioCodeUpgraderTests.cs
@@ -28,12 +28,12 @@ public class VisualStudioCodeUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(launchFile);
+        string actualContent = await File.ReadAllTextAsync(launchFile, fixture.CancellationToken);
         var launch = JsonDocument.Parse(actualContent);
 
         launch.RootElement.ValueKind.ShouldBe(JsonValueKind.Object);
@@ -57,7 +57,7 @@ public class VisualStudioCodeUpgraderTests(ITestOutputHelper outputHelper)
         property.GetString().ShouldBe("\\bNow listening on:\\s+(https?://\\S+)");
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -93,7 +93,7 @@ public class VisualStudioCodeUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -217,16 +217,16 @@ public class VisualStudioCodeUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(filePath);
+        string actualContent = await File.ReadAllTextAsync(filePath, fixture.CancellationToken);
         actualContent.Trim().ShouldBe(expectedContent.Trim());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -279,15 +279,15 @@ public class VisualStudioCodeUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(filePath);
+        string actualContent = await File.ReadAllTextAsync(filePath, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(filePath);
+        byte[] actualBytes = await File.ReadAllBytesAsync(filePath, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -299,7 +299,7 @@ public class VisualStudioCodeUpgraderTests(ITestOutputHelper outputHelper)
         }
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);

--- a/tests/DotNetBumper.Tests/Upgraders/VisualStudioComponentUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/VisualStudioComponentUpgraderTests.cs
@@ -28,16 +28,16 @@ public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(serverlessFile);
+        string actualContent = await File.ReadAllTextAsync(serverlessFile, fixture.CancellationToken);
         actualContent.ShouldContain($"\"Microsoft.NetCore.Component.Runtime.{channel}\"");
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -98,16 +98,16 @@ public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(vsconfig);
+        string actualContent = await File.ReadAllTextAsync(vsconfig, fixture.CancellationToken);
         actualContent.NormalizeLineEndings().TrimEnd().ShouldBe(expectedContent.NormalizeLineEndings().TrimEnd());
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);
@@ -140,7 +140,7 @@ public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actual = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actual = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actual.ShouldBe(ProcessingResult.None);
@@ -189,15 +189,15 @@ public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(fixture);
 
         // Act
-        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        ProcessingResult actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.Success);
 
-        string actualContent = await File.ReadAllTextAsync(configFile);
+        string actualContent = await File.ReadAllTextAsync(configFile, fixture.CancellationToken);
         actualContent.ShouldBe(expectedContent);
 
-        byte[] actualBytes = await File.ReadAllBytesAsync(configFile);
+        byte[] actualBytes = await File.ReadAllBytesAsync(configFile, fixture.CancellationToken);
 
         if (hasUtf8Bom)
         {
@@ -209,7 +209,7 @@ public class VisualStudioComponentUpgraderTests(ITestOutputHelper outputHelper)
         }
 
         // Act
-        actualUpdated = await target.UpgradeAsync(upgrade, CancellationToken.None);
+        actualUpdated = await target.UpgradeAsync(upgrade, fixture.CancellationToken);
 
         // Assert
         actualUpdated.ShouldBe(ProcessingResult.None);


### PR DESCRIPTION
- Port changes from https://github.com/martincostello/dotnet-bumper/pull/533 to prepare for adoption of xunit v3.
- When `--verbose` is specified, log more detail about failing tests.
- Fix `dotnet` being located in the wrong directory on Ubuntu 24.04 if `DOTNET_ROOT` is not set.
