### PR TITLE
Specify maximum package version

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -89,9 +89,8 @@ jobs:
             upgrade-type: Latest
           - repo: dotnet-bumper-test
             upgrade-type: Latest
-          # TODO Depends on https://github.com/martincostello/dotnet-bumper/pull/579
-          #- repo: dotnet-bumper-test
-          #  upgrade-type: LTS
+          - repo: dotnet-bumper-test
+            upgrade-type: LTS
           - repo: project-euler
             upgrade-type: Latest
           - repo: website

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ remainingReferencesIgnore:
 
 - .NET 8 must be installed to use the tool
   - The .NET SDK version to upgrade to must also be installed if this is different
-- The [dotnet-outdated][dotnet-outdated] .NET Global tool must also be installed
+- The [dotnet-outdated][dotnet-outdated] .NET Global tool must also be installed (v4.6.5 or later is recommended)
 - Any project being upgraded must already target at least .NET 6
 
 ## Questions

--- a/tests/DotNetBumper.Tests/Upgraders/PackageVersionUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/PackageVersionUpgraderTests.cs
@@ -69,9 +69,7 @@ public class PackageVersionUpgraderTests(ITestOutputHelper outputHelper)
 
         NuGetVersion.TryParse(upgradedReferences[prereleaseDependency], out var version).ShouldBeTrue();
         version.IsPrerelease.ShouldBeFalse();
-
-        // TODO Depends on https://github.com/martincostello/dotnet-bumper/issues/499
-        /*version.Major.ShouldBe(channel.Major);
+        version.Major.ShouldBe(channel.Major);
         version.Minor.ShouldBe(channel.Minor);
         version.Patch.ShouldBeGreaterThanOrEqualTo(0);
 
@@ -79,7 +77,7 @@ public class PackageVersionUpgraderTests(ITestOutputHelper outputHelper)
         version.IsPrerelease.ShouldBeFalse();
         version.Major.ShouldBe(channel.Major);
         version.Minor.ShouldBe(channel.Minor);
-        version.Patch.ShouldBeGreaterThan(0);*/
+        version.Patch.ShouldBeGreaterThan(0);
     }
 
     private static PackageVersionUpgrader CreateTarget(UpgraderFixture fixture)


### PR DESCRIPTION
Fix scenario where upgrades to .NET 8 include NuGet packages for .NET 9.

~~Depends on a new release of [dotnet-outdated-tool](https://www.nuget.org/packages/dotnet-outdated-tool/) including https://github.com/dotnet-outdated/dotnet-outdated/pull/640.~~ 🚢

Resolves #499.
