### PR TITLE
Refactoring from investigating issue fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,6 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
-          7.0.x
           8.0.x
           9.0.x
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
     outputs:
       dotnet-outdated-version: ${{ steps.get-dotnet-outdated-version.outputs.dotnet-outdated-version }}
-      dotnet-sdk-version: ${{ steps.get-dotnet-sdk-version.outputs.dotnet-sdk-version }}
+      dotnet-sdk-version: ${{ steps.get-dotnet-sdk-version.outputs.dotnet-version }}
 
     steps:
 
@@ -53,6 +53,7 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
+      id: get-dotnet-sdk-version
 
     - name: Publish NuGet package
       shell: pwsh
@@ -66,13 +67,6 @@ jobs:
         name: packages
         path: ./artifacts/package/release
         if-no-files-found: error
-
-    - name: Get .NET SDK version
-      id: get-dotnet-sdk-version
-      shell: pwsh
-      run: |
-        $dotnetSdkVersion = (Get-Content "./global.json" | Out-String | ConvertFrom-Json).sdk.version
-        "dotnet-sdk-version=${dotnetSdkVersion}" >> $env:GITHUB_OUTPUT
 
     - name: Get dotnet-outdated version
       id: get-dotnet-outdated-version

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,15 +42,6 @@ jobs:
         filter: 'tree:0'
         show-progress: false
 
-    - name: Install .NET SDKs
-      uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
-      with:
-        dotnet-version: |
-          6.0.x
-          7.0.x
-          8.0.x
-          9.0.x
-
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       id: get-dotnet-sdk-version

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Nullable>enable</Nullable>
     <PackageIcon>package-icon.png</PackageIcon>

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -29,13 +29,13 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
 #pragma warning disable IDE0090
         var testCases = new TheoryData<BumperTestCase>
         {
-            new BumperTestCase("7.0.100", ["net6.0", "net7.0"]),
             new BumperTestCase("6.0.100", ["net6.0"], ["--channel=8.0"]),
             new BumperTestCase("6.0.100", ["net6.0"], ["--channel=9.0"]),
             new BumperTestCase("6.0.100", ["net6.0"], ["--upgrade-type=latest"]),
             new BumperTestCase("6.0.100", ["net6.0"], ["--upgrade-type=lts"]),
             new BumperTestCase("6.0.100", ["net6.0"], [], Packages(("System.Text.Json", "6.0.0"))),
             new BumperTestCase("7.0.100", ["net7.0"], [], Packages(("System.Text.Json", "7.0.0"))),
+            new BumperTestCase("8.0.100", ["net6.0", "net8.0"], ["--channel=9.0"]),
         };
 #pragma warning restore IDE0090
 

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -237,6 +237,11 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
 
         List<string> args = [];
 
+        if (IsDebug())
+        {
+            args.Add("--verbose");
+        }
+
         if (runTests)
         {
             args.Add("--test");
@@ -553,7 +558,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
 
 #if DEBUG
         const string Verbose = "--verbose";
-        if (!arguments.Contains(Verbose) && Environment.GetEnvironmentVariable("RUNNER_DEBUG") is "1")
+        if (!arguments.Contains(Verbose) && IsDebug())
         {
             arguments = [.. arguments, Verbose];
         }
@@ -576,6 +581,9 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
         script.ShouldNotContain($" net{channel} ");
         script.ShouldContain(" win-x64 ");
     }
+
+    private static bool IsDebug()
+        => Environment.GetEnvironmentVariable("RUNNER_DEBUG") is "1";
 
     private static Dictionary<string, string> Packages(params (string Name, string Version)[] packages)
         => packages.ToDictionary((p) => p.Name, (p) => p.Version);

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -9,13 +9,11 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 
     public static TheoryData<string> Channels()
     {
-#pragma warning disable IDE0028 // See https://github.com/dotnet/roslyn/issues/72668
-        return new()
-        {
+        return
+        [
             "8.0",
             "9.0",
-        };
-#pragma warning restore IDE0028
+        ];
     }
 
     [Theory]
@@ -23,7 +21,6 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
     public async Task UpgradeAsync_Applies_Code_Fix(string channel)
     {
         Assert.SkipWhen(channel is "8.0", "See https://github.com/dotnet/sdk/issues/39742");
-        Assert.SkipWhen(channel is "9.0", "See https://github.com/dotnet/sdk/issues/39909 and https://github.com/dotnet/sdk/issues/40174");
 
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
@@ -74,7 +71,6 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
     public async Task UpgradeAsync_Applies_Code_Fixes(string channel)
     {
         Assert.SkipWhen(channel is "8.0", "See https://github.com/dotnet/sdk/issues/39742");
-        Assert.SkipWhen(channel is "9.0", "See https://github.com/dotnet/sdk/issues/39909 and https://github.com/dotnet/sdk/issues/40174");
 
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
@@ -128,9 +124,6 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
     [MemberData(nameof(Channels))]
     public async Task UpgradeAsync_Honors_User_Project_Settings(string channel)
     {
-        Assert.SkipWhen(channel is "8.0", "See https://github.com/dotnet/sdk/issues/39742");
-        Assert.SkipWhen(channel is "9.0", "See https://github.com/dotnet/sdk/issues/39909 and https://github.com/dotnet/sdk/issues/40174");
-
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
 
@@ -172,9 +165,6 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
     [MemberData(nameof(Channels))]
     public async Task UpgradeAsync_Does_Not_Fix_Information_Diagnostics(string channel)
     {
-        Assert.SkipWhen(channel is "8.0", "See https://github.com/dotnet/sdk/issues/39742");
-        Assert.SkipWhen(channel is "9.0", "See https://github.com/dotnet/sdk/issues/39909 and https://github.com/dotnet/sdk/issues/40174");
-
         // Arrange
         var upgrade = await GetUpgradeAsync(channel);
 


### PR DESCRIPTION
Refactoring from investigating candidate fix for #499:

- Use actions/setup-dotnet to get the SDK version.
- Remove the dependency on the .NET 7 SDK to run the tests.
- Remove redundant .NET SDK install step for multiple versions.
- Enable `MSBuildTreatWarningsAsErrors`.
- Enable `--verbose` in test if debugging in GitHub Actions CI.
- Enable tests that were skipped for issues that are now resolved.
- Extend test to prepare for fix for #499.
