### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,5 +28,6 @@ updates:
     - dependency-name: Microsoft.Build
     - dependency-name: Microsoft.Build.Utilities.Core
     - dependency-name: Microsoft.TestPlatform.ObjectModel
+    - dependency-name: System.Management.Automation
     - dependency-name: System.Text.Json
       update-types: ["version-update:semver-major"]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Spectre.Console.Testing" Version="0.49.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="9.0.1" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Management.Automation" Version="7.4.6" />
+    <PackageVersion Include="System.Management.Automation" Version="7.4.7" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
     <PackageVersion Include="xunit.v3" Version="1.0.1" />
@@ -39,6 +39,7 @@
   </ItemGroup>
   <ItemGroup Condition=" $([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0')) ">
     <PackageVersion Update="Microsoft.Build" Version="17.12.6" />
-    <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.12.6" />    
+    <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.12.6" />
+    <PackageVersion Update="System.Management.Automation" Version="7.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix dependabot failing to update System.Management.Automation due to the latest version only supporting .NET 9.
