### PR TITLE
Tidy-up templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,7 @@
-<!-- markdownlint-disable MD041 -->
+---
+title: ''
+---
+
 ### Expected behaviour
 
 <!-- Explain what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,10 @@
 ---
 name: Bug report
+title: Bug report
 about: Create a bug report to help us improve this project
 labels: bug
 ---
 
-<!-- markdownlint-disable MD041 -->
 ### Describe the bug
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,10 @@
 ---
 name: Feature request
+title: Feature request
 about: Suggest an idea for a feature for this project
 labels: feature-request
 ---
 
-<!-- markdownlint-disable MD041 -->
 ### Is your feature request related to a problem?
 
 <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,8 @@
     <AnalysisMode>All</AnalysisMode>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)DotNetBumper.snk</AssemblyOriginatorKeyFile>
     <Authors>martin_costello</Authors>
+    <!-- HACK Workaround for https://github.com/dotnet/sdk/issues/17454 -->
+    <BuildInParallel Condition="$([MSBuild]::IsOSPlatform('Windows'))">false</BuildInParallel>
     <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)DotNetBumper.ruleset</CodeAnalysisRuleSet>
     <Company>https://github.com/martincostello/dotnet-bumper</Company>


### PR DESCRIPTION
Tidy up the suppressions for markdownlint to make the templates render better in the GitHub UI.
