### PR TITLE
Add previews to test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
           6.0.x
           8.0.x
           9.0.x
+          10.0.x
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
@@ -84,6 +85,8 @@ jobs:
 
     - name: Build, Test and Package
       id: build
+      env:
+        DOTNET_HAS_PREVIEW: ${{ vars.DOTNET_HAS_PREVIEW }}
       shell: pwsh
       run: ./build.ps1
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,10 +82,12 @@ jobs:
           - repo: alexa-london-travel-site
             upgrade-type: Latest
           - repo: alexa-london-travel-site
+            test: false
             upgrade-type: Preview
           - repo: apple-fitness-workout-mapper
             upgrade-type: Latest
           - repo: apple-fitness-workout-mapper
+            test: false
             upgrade-type: Preview
           - repo: costellobot
             upgrade-type: Latest
@@ -98,6 +100,7 @@ jobs:
           - repo: dotnet-bumper
             upgrade-type: Latest
           - repo: dotnet-bumper
+            test: false
             upgrade-type: Preview
           - repo: dotnet-bumper-test
             upgrade-type: Latest
@@ -185,7 +188,7 @@ jobs:
       shell: pwsh
       env:
         DOTNET_BUMPER_CONFIG: ${{ steps.generate-config.outputs.dotnet-bumper-config }}
-        DOTNET_BUMPER_TEST: 'true' # ${{ format('{0}', matrix.test) }}
+        DOTNET_BUMPER_TEST: ${{ format('{0}', matrix.test) }}
         DOTNET_BUMPER_UPGRADE_TYPE: ${{ matrix.upgrade-type }}
         DOTNET_BUMPER_WARNINGS_AS_ERRORS: 'true' # ${{ format('{0}', matrix.warnings-as-errors) }}
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,24 +77,42 @@ jobs:
         include:
           - repo: alexa-london-travel
             upgrade-type: Latest
+          - repo: alexa-london-travel
+            upgrade-type: Preview
           - repo: alexa-london-travel-site
             upgrade-type: Latest
+          - repo: alexa-london-travel-site
+            upgrade-type: Preview
           - repo: apple-fitness-workout-mapper
             upgrade-type: Latest
+          - repo: apple-fitness-workout-mapper
+            upgrade-type: Preview
           - repo: costellobot
             upgrade-type: Latest
+          - repo: costellobot
+            upgrade-type: Preview
           - repo: dependabot-helper
             upgrade-type: Latest
+          - repo: dependabot-helper
+            upgrade-type: Preview
           - repo: dotnet-bumper
             upgrade-type: Latest
+          - repo: dotnet-bumper
+            upgrade-type: Preview
           - repo: dotnet-bumper-test
             upgrade-type: Latest
           - repo: dotnet-bumper-test
             upgrade-type: LTS
+          - repo: dotnet-bumper-test
+            upgrade-type: Preview
           - repo: project-euler
             upgrade-type: Latest
+          - repo: project-euler
+            upgrade-type: Preview
           - repo: website
             upgrade-type: Latest
+          - repo: website
+            upgrade-type: Preview
 
     steps:
 
@@ -120,6 +138,7 @@ jobs:
           7.0.x
           8.0.x
           9.0.x
+          10.0.x
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -84,6 +84,7 @@ jobs:
           - repo: alexa-london-travel-site
             test: false
             upgrade-type: Preview
+            warnings-as-errors: false
           - repo: apple-fitness-workout-mapper
             upgrade-type: Latest
           - repo: apple-fitness-workout-mapper
@@ -190,7 +191,7 @@ jobs:
         DOTNET_BUMPER_CONFIG: ${{ steps.generate-config.outputs.dotnet-bumper-config }}
         DOTNET_BUMPER_TEST: ${{ format('{0}', matrix.test) }}
         DOTNET_BUMPER_UPGRADE_TYPE: ${{ matrix.upgrade-type }}
-        DOTNET_BUMPER_WARNINGS_AS_ERRORS: 'true' # ${{ format('{0}', matrix.warnings-as-errors) }}
+        DOTNET_BUMPER_WARNINGS_AS_ERRORS: ${{ format('{0}', matrix.warnings-as-errors) }}
       run: |
         $bumperArgs = @(
           ".",

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <GenerateGitMetadata Condition=" '$(CI)' != '' and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
+    <GenerateGitMetadata Condition=" '$(CI)' != '' AND '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
@@ -42,7 +42,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <SignAssembly>false</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' AND '$(SignAssembly)' == 'true' ">true</PublicSign>
+    <PublicSign Condition=" !$([MSBuild]::IsOSPlatform('Windows')) AND '$(SignAssembly)' == 'true' ">true</PublicSign>
     <StrongNamePublicKey Condition=" '$(SignAssembly)' == 'true'">00240000048000009400000006020000002400005253413100040000010001004b0b2efbada897147aa03d2076278890aefe2f8023562336d206ec8a719b06e89461c31b43abec615918d509158629f93385930c030494509e418bf396d69ce7dbe0b5b2db1a81543ab42777cb98210677fed69dbeb3237492a7ad69e87a1911ed20eb2d7c300238dc6f6403e3d04a1351c5cb369de4e022b18fbec70f7d21ed</StrongNamePublicKey>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -57,7 +57,7 @@
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>
     <FileVersion Condition=" '$(GITHUB_RUN_NUMBER)' != '' ">$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(EnableReferenceTrimmer)' != 'false' and '$(GenerateDocumentationFile)' != 'true' ">
+  <PropertyGroup Condition=" '$(EnableReferenceTrimmer)' != 'false' AND '$(GenerateDocumentationFile)' != 'true' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);419;1570;1573;1574;1584;1591;SA0001;SA1602</NoWarn>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,7 +5,7 @@
   </ItemGroup>
   <PropertyGroup>
     <CommitBranch Condition=" '$(CommitBranch)' == '' ">$(BUILD_SOURCEBRANCHNAME)</CommitBranch>
-    <CommitBranch Condition=" '$(CommitBranch)' == '' and '$(GITHUB_REF_NAME)' != '' ">$(GITHUB_REF_NAME)</CommitBranch>
+    <CommitBranch Condition=" '$(CommitBranch)' == '' AND '$(GITHUB_REF_NAME)' != '' ">$(GITHUB_REF_NAME)</CommitBranch>
     <CommitHash Condition=" '$(CommitHash)' == '' ">$(GITHUB_SHA)</CommitHash>
   </PropertyGroup>
   <Target Name="AddGitMetadaAssemblyAttributes"

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -39,13 +39,15 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
         };
 #pragma warning restore IDE0090
 
+        // TODO Dynamically work out if there's a preview available
         // These test cases only work when there's actually a preview in development
         if (Environment.GetEnvironmentVariable("DOTNET_HAS_PREVIEW") is "true")
         {
             testCases.AddRange(
                 [
                     new BumperTestCase("6.0.100", ["net6.0"], ["--upgrade-type=preview"]),
-                    new BumperTestCase("8.0.100", ["net8.0"], ["--upgrade-type=preview"], Packages(("System.Text.Json", "8.0.0"))),
+                    new BumperTestCase("8.0.100", ["net8.0"], ["--upgrade-type=preview"], Packages(("Microsoft.Extensions.Configuration.UserSecrets", "8.0.0"))),
+                    new BumperTestCase("9.0.100", ["net9.0"], ["--upgrade-type=preview"], Packages(("Microsoft.Extensions.Configuration.UserSecrets", "9.0.0"))),
                 ]);
         }
 


### PR DESCRIPTION
- Add previews back into the test matrix now that .NET 10 preview 1 is available.
- Consistent casing of `AND`.
- Use `$([MSBuild]::IsOSPlatform('Windows'))`.
