### PR TITLE
Support .NET Daily Builds

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -6,13 +6,15 @@
       "version": "4.6.8",
       "commands": [
         "dotnet-outdated"
-      ]
+      ],
+      "rollForward": true
     },
     "dotnet-validate": {
       "version": "0.0.1-preview.304",
       "commands": [
         "dotnet-validate"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -109,6 +109,8 @@ jobs:
             upgrade-type: LTS
           - repo: dotnet-bumper-test
             upgrade-type: Preview
+          - repo: dotnet-bumper-test
+            upgrade-type: Daily
           - repo: project-euler
             upgrade-type: Latest
           - repo: project-euler

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -109,8 +109,6 @@ jobs:
             upgrade-type: LTS
           - repo: dotnet-bumper-test
             upgrade-type: Preview
-          - repo: dotnet-bumper-test
-            upgrade-type: Daily
           - repo: project-euler
             upgrade-type: Latest
           - repo: project-euler

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,9 +8,9 @@
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
     <PackageTags>dotnet,migrate,migration,sdk,tool,update,upgrade</PackageTags>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <AssemblyVersion>0.9.0.0</AssemblyVersion>
+    <AssemblyVersion>0.10.0.0</AssemblyVersion>
     <PackageValidationBaselineVersion>0.9.2</PackageValidationBaselineVersion>
-    <VersionPrefix>0.9.3</VersionPrefix>
+    <VersionPrefix>0.10.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(EnableReferenceTrimmer)' != 'false' AND '$(GenerateDocumentationFile)' != 'true' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Upgrades projects to a newer version of .NET.
 Usage: dotnet bumper [options] <ProjectPath>
 
 Arguments:
-  ProjectPath                      The path to directory containing a .NET 6+ project to be upgraded. If not specified,
-                                   the current directory will be used.
+  ProjectPath                      The path to directory containing a .NET 6+ project to be upgraded. If not
+                                   specified, the current directory will be used.
 
 Options:
   -v|--verbose                     Show verbose output
@@ -110,8 +110,10 @@ Options:
                                    Default value is: None.
   -lp|--log-path <PATH>            The path to write the log file to, if any.
   -q|--no-logo                     Do not display the startup banner.
+  -ql|--quality <QUALITY>          The type of quality to use for .NET daily builds.
+                                   Allowed values are: Daily, Signed, Validated, Preview.
   -t|--upgrade-type <TYPE>         The type of upgrade to perform.
-                                   Allowed values are: Lts, Latest, Preview.
+                                   Allowed values are: Lts, Latest, Preview, Daily.
   -test|--test                     Test the upgrade by running dotnet test on completion.
   -timeout|--timeout <TIMESPAN>    The optional period to timeout the upgrade after.
   -e|--warnings-as-errors          Treat any warnings encountered during the upgrade as errors.

--- a/src/DotNetBumper.Core/BumperConfigurationProvider.cs
+++ b/src/DotNetBumper.Core/BumperConfigurationProvider.cs
@@ -32,7 +32,7 @@ internal sealed partial class BumperConfigurationProvider(
             },
         };
 
-        if (options.Value.UpgradeType is UpgradeType.Preview)
+        if (options.Value.UpgradeType.IsPrerelease())
         {
             configuration.NoWarn.Add("NETSDK1057");
             configuration.NoWarn.Add("NU5104");

--- a/src/DotNetBumper.Core/DotNetBumper.Core.csproj
+++ b/src/DotNetBumper.Core/DotNetBumper.Core.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Description>A library containing types for upgrading projects to a newer version of .NET.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsAotCompatible>false</IsAotCompatible>
     <IsPackable>false</IsPackable>
     <OutputType>Library</OutputType>
     <PackageId>MartinCostello.DotNetBumper.Core</PackageId>

--- a/src/DotNetBumper.Core/DotNetInstaller.cs
+++ b/src/DotNetBumper.Core/DotNetInstaller.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using NuGet.Versioning;
+
+namespace MartinCostello.DotNetBumper;
+
+/// <summary>
+/// A class that installs the .NET SDK. This class cannot be inherited.
+/// </summary>
+/// <param name="httpClient">The <see cref="HttpClient"/> to use.</param>
+/// <param name="logger">The <see cref="ILogger"/> to use.</param>
+internal sealed partial class DotNetInstaller(HttpClient httpClient, ILogger logger)
+{
+    public async Task InstallAsync(NuGetVersion sdkVersion, CancellationToken cancellationToken)
+    {
+        var version = sdkVersion.ToString();
+        var installationPath = EnsureInstallationPath();
+
+        if (IsDotNetSdkInstalled(installationPath, version))
+        {
+            SetDotNetRoot(installationPath);
+            Log.SdkAlreadyInstalled(logger, version);
+            return;
+        }
+
+        var scriptPath = await DownloadInstallScriptAsync(installationPath, cancellationToken);
+
+        var command = OperatingSystem.IsWindows() ? "powershell" : scriptPath;
+
+        string[] scriptArgs =
+            OperatingSystem.IsWindows() ?
+            ["-File", scriptPath, "-Version", version, "-InstallDir", installationPath, "-SkipNonVersionedFiles"] :
+            ["--version", version, "--install-dir", installationPath, "--skip-non-versioned-files"];
+
+        var startInfo = new ProcessStartInfo(command, scriptArgs)
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+        };
+
+        Log.InstallingSdk(logger, version);
+
+        var result = await ProcessHelper.RunAsync(startInfo, cancellationToken);
+
+        if (result.Success)
+        {
+            SetDotNetRoot(installationPath);
+            Log.InstalledSdk(logger, version);
+        }
+        else
+        {
+            Log.InstallationFailed(logger, Path.GetFileName(scriptPath), result);
+        }
+
+        static void SetDotNetRoot(string installationPath) =>
+            Environment.SetEnvironmentVariable(
+                WellKnownEnvironmentVariables.DotNetRoot,
+                installationPath,
+                EnvironmentVariableTarget.Process);
+    }
+
+    private static string EnsureDirectory(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            Directory.CreateDirectory(path);
+        }
+
+        return path;
+    }
+
+    private static string EnsureTemporaryDirectory()
+        => EnsureDirectory(Path.Join(Path.GetTempPath(), "dotnet-bumper"));
+
+    private static string EnsureInstallationPath()
+        => EnsureDirectory(Path.Join(EnsureTemporaryDirectory(), ".dotnet"));
+
+    private static bool IsDotNetSdkInstalled(string installationPath, string version)
+    {
+        var sdkPath = Path.Combine(installationPath, "sdk", version);
+        return Directory.Exists(sdkPath);
+    }
+
+    private async Task<string> DownloadInstallScriptAsync(
+        string directoryPath,
+        CancellationToken cancellationToken)
+    {
+        var isWindows = OperatingSystem.IsWindows();
+        var extension = isWindows ? "ps1" : "sh";
+        var fileName = $"dotnet-install.{extension}";
+
+        var requestUri = new Uri($"https://dot.net/v1/{fileName}");
+
+        var scriptBytes = await httpClient.GetByteArrayAsync(requestUri, cancellationToken);
+
+        var scriptPath = Path.Join(directoryPath, fileName);
+
+        await File.WriteAllBytesAsync(scriptPath, scriptBytes, cancellationToken);
+
+        if (!isWindows)
+        {
+            // Make the script executable
+            using var chmod = Process.Start("chmod", ["+x", scriptPath]);
+            if (chmod is not null)
+            {
+                await chmod.WaitForExitAsync(cancellationToken);
+            }
+        }
+
+        return scriptPath;
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 1,
+            Level = LogLevel.Information,
+            Message = "Version {Version} of the .NET SDK is already installed.")]
+        public static partial void SdkAlreadyInstalled(ILogger logger, string version);
+
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Information,
+            Message = "Installing version {Version} of the .NET SDK.")]
+        public static partial void InstallingSdk(ILogger logger, string version);
+
+        [LoggerMessage(
+            EventId = 3,
+            Level = LogLevel.Information,
+            Message = "Installed version {Version} of the .NET SDK successfully.")]
+        public static partial void InstalledSdk(ILogger logger, string version);
+
+        public static void InstallationFailed(
+            ILogger logger,
+            string fileName,
+            ProcessResult process)
+        {
+            InstallFailed(logger, fileName, process.ExitCode);
+
+            if (!string.IsNullOrEmpty(process.StandardOutput))
+            {
+                InstallFailedOutput(logger, fileName, process.StandardOutput);
+            }
+
+            if (!string.IsNullOrEmpty(process.StandardError))
+            {
+                InstallFailedError(logger, fileName, process.StandardError);
+            }
+        }
+
+        [LoggerMessage(
+            EventId = 4,
+            Level = LogLevel.Warning,
+            Message = "{InstallerScript} failed with exit code {ExitCode}.")]
+        public static partial void InstallFailed(ILogger logger, string installerScript, int exitCode);
+
+        [LoggerMessage(
+            EventId = 5,
+            Level = LogLevel.Warning,
+            Message = "{InstallerScript} standard output: {Output}")]
+        public static partial void InstallFailedOutput(ILogger logger, string installerScript, string output);
+
+        [LoggerMessage(
+            EventId = 6,
+            Level = LogLevel.Error,
+            Message = "{InstallerScript} standard error: {Error}")]
+        public static partial void InstallFailedError(ILogger logger, string installerScript, string error);
+    }
+}

--- a/src/DotNetBumper.Core/DotNetInstaller.cs
+++ b/src/DotNetBumper.Core/DotNetInstaller.cs
@@ -14,7 +14,7 @@ namespace MartinCostello.DotNetBumper;
 /// <param name="logger">The <see cref="ILogger"/> to use.</param>
 internal sealed partial class DotNetInstaller(HttpClient httpClient, ILogger logger)
 {
-    public async Task InstallAsync(NuGetVersion sdkVersion, CancellationToken cancellationToken)
+    public async Task TryInstallAsync(NuGetVersion sdkVersion, CancellationToken cancellationToken)
     {
         var version = sdkVersion.ToString();
         var installationPath = EnsureInstallationPath();

--- a/src/DotNetBumper.Core/DotNetQuality.cs
+++ b/src/DotNetBumper.Core/DotNetQuality.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper;
+
+/// <summary>
+/// An enumeration representing the quality of a .NET release.
+/// </summary>
+public enum DotNetQuality
+{
+    /// <summary>
+    /// A daily build.
+    /// </summary>
+    Daily,
+
+    /// <summary>
+    /// A signed build.
+    /// </summary>
+    Signed,
+
+    /// <summary>
+    /// A validated build.
+    /// </summary>
+    Validated,
+
+    /// <summary>
+    /// A preview build.
+    /// </summary>
+    Preview,
+}

--- a/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
+++ b/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
@@ -150,6 +150,7 @@ public partial class DotNetUpgradeFinder(
 
             return options.Value.UpgradeType switch
             {
+                UpgradeType.Daily => true,
                 UpgradeType.Preview => channel.SdkVersion.IsPrerelease,
                 UpgradeType.Lts => channel.ReleaseType is DotNetReleaseType.Lts && !channel.SdkVersion.IsPrerelease,
                 _ => !channel.SdkVersion.IsPrerelease,

--- a/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
+++ b/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
@@ -95,7 +95,7 @@ public partial class DotNetUpgradeFinder(
         return releaseDate;
     }
 
-    private async Task<UpgradeInfo> GetDailyBuildAsync(CancellationToken cancellationToken)
+    private async Task<UpgradeInfo?> GetDailyBuildAsync(CancellationToken cancellationToken)
     {
 #pragma warning disable CA1308
         var quality = options.Value.Quality.ToString().ToLowerInvariant();

--- a/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
+++ b/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
@@ -67,6 +67,9 @@ public partial class DotNetUpgradeFinder(
                 return null;
             }
 
+            var installer = new DotNetInstaller(httpClient, logger);
+            await installer.InstallAsync(sdkVersion, cancellationToken);
+
             // TODO Compute when Update Tuesday in November will be and set that as the date
             var utcNow = DateOnly.FromDateTime(TimeProvider.System.GetUtcNow().UtcDateTime);
             var endOfLife = new DateOnly(utcNow.Year, 11, 14);

--- a/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
+++ b/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Versioning;
@@ -41,6 +42,7 @@ public partial class DotNetUpgradeFinder(
 
         using var releasesIndex = await httpClient.GetFromJsonAsync<JsonDocument>(
             "https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases-index.json",
+            DotNetJsonSerializationContext.Default.JsonDocument,
             cancellationToken);
 
         if (releasesIndex is null)
@@ -204,4 +206,9 @@ public partial class DotNetUpgradeFinder(
             string sdkVersion,
             DotNetReleaseType releaseType);
     }
+
+    [ExcludeFromCodeCoverage]
+    [JsonSerializable(typeof(JsonDocument))]
+    [JsonSourceGenerationOptions]
+    private sealed partial class DotNetJsonSerializationContext : JsonSerializerContext;
 }

--- a/src/DotNetBumper.Core/PostProcessors/IPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/IPostProcessor.cs
@@ -9,11 +9,6 @@ namespace MartinCostello.DotNetBumper.PostProcessors;
 public interface IPostProcessor
 {
     /// <summary>
-    /// Gets the global order the post-processor should run in where lower numbers run before higher numbers.
-    /// </summary>
-    int Order { get; }
-
-    /// <summary>
     /// Runs a post-processing after an upgrade to the project.
     /// </summary>
     /// <param name="upgrade">The version of .NET to upgrade to.</param>

--- a/src/DotNetBumper.Core/ProcessHelper.cs
+++ b/src/DotNetBumper.Core/ProcessHelper.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace MartinCostello.DotNetBumper;
+
+internal static class ProcessHelper
+{
+    public static async Task<ProcessResult> RunAsync(
+        ProcessStartInfo startInfo,
+        CancellationToken cancellationToken)
+    {
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException($"Failed to start process for {startInfo.FileName}.");
+
+        // See https://stackoverflow.com/a/16326426/1064169 and
+        // https://learn.microsoft.com/dotnet/api/system.diagnostics.processstartinfo.redirectstandardoutput.
+        using var outputTokenSource = new CancellationTokenSource();
+        var readOutput = ReadOutputAsync(process, outputTokenSource.Token);
+
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (Exception)
+            {
+                // Ignore
+            }
+        }
+        finally
+        {
+            await outputTokenSource.CancelAsync();
+        }
+
+        (string error, string output) = await readOutput;
+
+        var result = new ProcessResult(
+            process.ExitCode == 0,
+            process.ExitCode,
+            output,
+            error);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return result;
+
+        static async Task<(string Error, string Output)> ReadOutputAsync(
+            Process process,
+            CancellationToken cancellationToken)
+        {
+            var processErrors = ConsumeStreamAsync(process.StandardError, process.StartInfo.RedirectStandardError, cancellationToken);
+            var processOutput = ConsumeStreamAsync(process.StandardOutput, process.StartInfo.RedirectStandardOutput, cancellationToken);
+
+            await Task.WhenAll(processErrors, processOutput);
+
+            string error = string.Empty;
+            string output = string.Empty;
+
+            if (processErrors.Status == TaskStatus.RanToCompletion)
+            {
+                error = (await processErrors).ToString();
+            }
+
+            if (processOutput.Status == TaskStatus.RanToCompletion)
+            {
+                output = (await processOutput).ToString();
+            }
+
+            return (error, output);
+        }
+
+        static Task<StringBuilder> ConsumeStreamAsync(
+            StreamReader reader,
+            bool isRedirected,
+            CancellationToken cancellationToken)
+        {
+            return isRedirected ?
+                Task.Run(() => ProcessStream(reader, cancellationToken), cancellationToken) :
+                Task.FromResult(new StringBuilder(0));
+
+            static async Task<StringBuilder> ProcessStream(
+                StreamReader reader,
+                CancellationToken cancellationToken)
+            {
+                var builder = new StringBuilder();
+
+                try
+                {
+                    builder.Append(await reader.ReadToEndAsync(cancellationToken));
+                }
+                catch (OperationCanceledException)
+                {
+                    // Ignore
+                }
+
+                return builder;
+            }
+        }
+    }
+}

--- a/src/DotNetBumper.Core/ProcessResult.cs
+++ b/src/DotNetBumper.Core/ProcessResult.cs
@@ -4,25 +4,14 @@
 namespace MartinCostello.DotNetBumper;
 
 /// <summary>
-/// Represents the result of running a .NET process.
+/// Represents the result of running a process.
 /// </summary>
 /// <param name="Success">Whether the process exited successfully.</param>
 /// <param name="ExitCode">The exit code from the process.</param>
 /// <param name="StandardOutput">The standard output from the process.</param>
 /// <param name="StandardError">The standard error from the process.</param>
-public sealed record DotNetResult(
+public record ProcessResult(
     bool Success,
     int ExitCode,
     string StandardOutput,
-    string StandardError) : ProcessResult(Success, ExitCode, StandardOutput, StandardError)
-{
-    /// <summary>
-    /// Gets or sets the build log from the process, if any.
-    /// </summary>
-    public BumperBuildLog? BuildLogs { get; set; }
-
-    /// <summary>
-    /// Gets or sets the test logs from the process, if any.
-    /// </summary>
-    public BumperTestLog? TestLogs { get; set; }
-}
+    string StandardError);

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -202,33 +202,45 @@ public partial class ProjectUpgrader(
         var sequence = new List<IUpgrader>(upgraders);
 
         // The SDK version in global.json must be updated first
-        var globalJsonIndex = sequence.FindIndex((p) => p is Upgraders.GlobalJsonUpgrader);
-        var globalJson = sequence[globalJsonIndex];
+        var index = sequence.FindIndex((p) => p is Upgraders.GlobalJsonUpgrader);
 
-        sequence.RemoveAt(globalJsonIndex);
-        sequence.Insert(0, globalJson);
+        if (index is > -1)
+        {
+            var globalJson = sequence[index];
+            sequence.RemoveAt(index);
+            sequence.Insert(0, globalJson);
+        }
 
         // The NuGet configuration needs to be updated before any package updates
-        var nugetConfigIndex = sequence.FindIndex((p) => p is Upgraders.NuGetConfigUpgrader);
-        var nugetConfig = sequence[nugetConfigIndex];
+        index = sequence.FindIndex((p) => p is Upgraders.NuGetConfigUpgrader);
 
-        sequence.RemoveAt(nugetConfigIndex);
-        sequence.Insert(1, nugetConfig);
+        if (index is > -1)
+        {
+            var nugetConfig = sequence[index];
+            sequence.RemoveAt(index);
+            sequence.Insert(1, nugetConfig);
+        }
 
         // Packages need to be updated after the TFM so the packages relate to the update but before any code is changed
-        var packageVersionsIndex = sequence.FindIndex((p) => p is Upgraders.PackageVersionUpgrader);
-        var packageVersions = sequence[packageVersionsIndex];
+        index = sequence.FindIndex((p) => p is Upgraders.PackageVersionUpgrader);
 
-        sequence.RemoveAt(packageVersionsIndex);
-        sequence.Add(packageVersions);
+        if (index is > -1)
+        {
+            var packageVersions = sequence[index];
+            sequence.RemoveAt(index);
+            sequence.Add(packageVersions);
+        }
 
         // The code upgrader/formatter must run after all other upgraders as analyzers may
         // have come as part of NuGet packages that were upgraded by dotnet-outdated-tool.
-        var codeIndex = sequence.FindIndex((p) => p is Upgraders.DotNetCodeUpgrader);
-        var code = sequence[codeIndex];
+        index = sequence.FindIndex((p) => p is Upgraders.DotNetCodeUpgrader);
 
-        sequence.RemoveAt(codeIndex);
-        sequence.Add(code);
+        if (index is > -1)
+        {
+            var code = sequence[index];
+            sequence.RemoveAt(index);
+            sequence.Add(code);
+        }
 
         foreach (var item in sequence)
         {

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -202,21 +202,21 @@ public partial class ProjectUpgrader(
         var sequence = new List<IUpgrader>(upgraders);
 
         // The SDK version in global.json must be updated first
-        var globalJsonIndex = sequence.FindIndex((p) => p.GetType() == typeof(Upgraders.GlobalJsonUpgrader));
+        var globalJsonIndex = sequence.FindIndex((p) => p is Upgraders.GlobalJsonUpgrader);
         var globalJson = sequence[globalJsonIndex];
 
         sequence.RemoveAt(globalJsonIndex);
         sequence.Insert(0, globalJson);
 
         // The NuGet configuration needs to be updated before any package updates
-        var nugetConfigIndex = sequence.FindIndex((p) => p.GetType() == typeof(Upgraders.NuGetConfigUpgrader));
+        var nugetConfigIndex = sequence.FindIndex((p) => p is Upgraders.NuGetConfigUpgrader);
         var nugetConfig = sequence[nugetConfigIndex];
 
         sequence.RemoveAt(nugetConfigIndex);
         sequence.Insert(1, nugetConfig);
 
         // Packages need to be updated after the TFM so the packages relate to the update but before any code is changed
-        var packageVersionsIndex = sequence.FindIndex((p) => p.GetType() == typeof(Upgraders.PackageVersionUpgrader));
+        var packageVersionsIndex = sequence.FindIndex((p) => p is Upgraders.PackageVersionUpgrader);
         var packageVersions = sequence[packageVersionsIndex];
 
         sequence.RemoveAt(packageVersionsIndex);
@@ -224,7 +224,7 @@ public partial class ProjectUpgrader(
 
         // The code upgrader/formatter must run after all other upgraders as analyzers may
         // have come as part of NuGet packages that were upgraded by dotnet-outdated-tool.
-        var codeIndex = sequence.FindIndex((p) => p.GetType() == typeof(Upgraders.DotNetCodeUpgrader));
+        var codeIndex = sequence.FindIndex((p) => p is Upgraders.DotNetCodeUpgrader);
         var code = sequence[codeIndex];
 
         sequence.RemoveAt(codeIndex);

--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -75,6 +75,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IUpgrader, DotNetCodeUpgrader>();
         services.AddSingleton<IUpgrader, GitHubActionsUpgrader>();
         services.AddSingleton<IUpgrader, GlobalJsonUpgrader>();
+        services.AddSingleton<IUpgrader, NuGetConfigUpgrader>();
         services.AddSingleton<IUpgrader, PackageVersionUpgrader>();
         services.AddSingleton<IUpgrader, PowerShellScriptUpgrader>();
         services.AddSingleton<IUpgrader, RuntimeIdentifierUpgrader>();

--- a/src/DotNetBumper.Core/UpgradeOptions.cs
+++ b/src/DotNetBumper.Core/UpgradeOptions.cs
@@ -50,4 +50,9 @@ public sealed class UpgradeOptions
     /// Gets or sets a value indicating whether to treat warnings as errors.
     /// </summary>
     public bool TreatWarningsAsErrors { get; set; }
+
+    /// <summary>
+    /// Gets or sets the .NET build quality to use for <see cref="UpgradeType.Daily"/>.
+    /// </summary>
+    public DotNetQuality Quality { get; set; }
 }

--- a/src/DotNetBumper.Core/UpgradeTask.cs
+++ b/src/DotNetBumper.Core/UpgradeTask.cs
@@ -13,8 +13,6 @@ internal abstract class UpgradeTask(
     IOptions<UpgradeOptions> options,
     ILogger logger)
 {
-    public virtual int Order => 0;
-
     protected IAnsiConsole Console { get; } = console;
 
     protected IEnvironment TaskEnvironment { get; } = environment;

--- a/src/DotNetBumper.Core/UpgradeType.cs
+++ b/src/DotNetBumper.Core/UpgradeType.cs
@@ -22,4 +22,9 @@ public enum UpgradeType
     /// Upgrade to the latest preview release.
     /// </summary>
     Preview,
+
+    /// <summary>
+    /// Upgrade to the latest daily release.
+    /// </summary>
+    Daily,
 }

--- a/src/DotNetBumper.Core/UpgradeTypeExtensions.cs
+++ b/src/DotNetBumper.Core/UpgradeTypeExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper;
+
+/// <summary>
+/// A class containing extension methods for <see cref="UpgradeType"/>. This class cannot be inherited.
+/// </summary>
+public static class UpgradeTypeExtensions
+{
+    /// <summary>
+    /// Returns whether the specified <see cref="UpgradeType"/> is a prerelease version.
+    /// </summary>
+    /// <param name="type">The <see cref="UpgradeType"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> if the <see cref="UpgradeType"/> is a prerelease version; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool IsPrerelease(this UpgradeType type)
+        => type is UpgradeType.Daily or UpgradeType.Preview;
+}

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -18,8 +18,6 @@ internal sealed partial class DotNetCodeUpgrader(
     IOptions<UpgradeOptions> options,
     ILogger<DotNetCodeUpgrader> logger) : FileUpgrader(console, environment, options, logger)
 {
-    public override int Order => int.MaxValue; // Run after all other upgraders
-
     protected override string Action => "Upgrading .NET code";
 
     protected override string InitialStatus => "Update .NET code";

--- a/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
@@ -18,7 +18,7 @@ internal sealed partial class GlobalJsonUpgrader(
     IOptions<UpgradeOptions> options,
     ILogger<GlobalJsonUpgrader> logger) : FileUpgrader(console, environment, options, logger)
 {
-    public override int Order => -1;
+    public override int Order => int.MinValue;
 
     protected override string Action => "Upgrading .NET SDK";
 

--- a/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
@@ -18,8 +18,6 @@ internal sealed partial class GlobalJsonUpgrader(
     IOptions<UpgradeOptions> options,
     ILogger<GlobalJsonUpgrader> logger) : FileUpgrader(console, environment, options, logger)
 {
-    public override int Order => int.MinValue;
-
     protected override string Action => "Upgrading .NET SDK";
 
     protected override string InitialStatus => "Update SDK version";

--- a/src/DotNetBumper.Core/Upgraders/IUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/IUpgrader.cs
@@ -9,11 +9,6 @@ namespace MartinCostello.DotNetBumper.Upgraders;
 public interface IUpgrader
 {
     /// <summary>
-    /// Gets the global order the upgrader should run in where lower numbers run before higher numbers.
-    /// </summary>
-    int Order { get; }
-
-    /// <summary>
     /// Attempts to apply an upgrade to the project.
     /// </summary>
     /// <param name="upgrade">The version of .NET to upgrade to.</param>

--- a/src/DotNetBumper.Core/Upgraders/NuGetConfigUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/NuGetConfigUpgrader.cs
@@ -16,8 +16,6 @@ internal sealed partial class NuGetConfigUpgrader(
     IOptions<UpgradeOptions> options,
     ILogger<NuGetConfigUpgrader> logger) : XmlFileUpgrader(console, environment, options, logger)
 {
-    public override int Order => int.MinValue + 1; // Needs to run before PackageVersionUpgrader
-
     protected override string Action => "Updating NuGet configuration file";
 
     protected override string InitialStatus => "Update NuGet configuration";

--- a/src/DotNetBumper.Core/Upgraders/NuGetConfigUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/NuGetConfigUpgrader.cs
@@ -1,0 +1,178 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+using MartinCostello.DotNetBumper.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+internal sealed partial class NuGetConfigUpgrader(
+    IAnsiConsole console,
+    IEnvironment environment,
+    BumperLogContext logContext,
+    IOptions<UpgradeOptions> options,
+    ILogger<NuGetConfigUpgrader> logger) : XmlFileUpgrader(console, environment, options, logger)
+{
+    public override int Order => int.MinValue + 1; // Needs to run before PackageVersionUpgrader
+
+    protected override string Action => "Updating NuGet configuration file";
+
+    protected override string InitialStatus => "Update NuGet configuration";
+
+#pragma warning disable CA1308
+    protected override IReadOnlyList<string> Patterns { get; } =
+    [
+        WellKnownFileNames.NuGetConfiguration,
+        WellKnownFileNames.NuGetConfiguration.ToLowerInvariant(),
+    ];
+#pragma warning restore CA1308
+
+    public override async Task<ProcessingResult> UpgradeAsync(UpgradeInfo upgrade, CancellationToken cancellationToken)
+    {
+        if (Options.UpgradeType is not UpgradeType.Daily)
+        {
+            // Suppress all output and ignore unless it's a daily build
+            return ProcessingResult.None;
+        }
+
+        return await base.UpgradeAsync(upgrade, cancellationToken);
+    }
+
+    protected override async Task<ProcessingResult> UpgradeCoreAsync(
+        UpgradeInfo upgrade,
+        StatusContext context,
+        CancellationToken cancellationToken)
+    {
+        var fileNames = FindFiles();
+
+        if (fileNames.Count == 0)
+        {
+            var fileName = Path.Combine(Options.ProjectPath, WellKnownFileNames.NuGetConfiguration);
+
+            var defaultConfiguration =
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+                  </packageSources>
+                  <packageSourceMapping>
+                    <packageSource key="NuGet">
+                      <package pattern="*" />
+                    </packageSource>
+                  </packageSourceMapping>
+                </configuration>
+                """;
+
+            await File.WriteAllTextAsync(fileName, defaultConfiguration, cancellationToken);
+
+            fileNames = [fileName];
+        }
+
+        return await UpgradeCoreAsync(upgrade, fileNames, context, cancellationToken);
+    }
+
+    protected override async Task<ProcessingResult> UpgradeCoreAsync(
+        UpgradeInfo upgrade,
+        IReadOnlyList<string> fileNames,
+        StatusContext context,
+        CancellationToken cancellationToken)
+    {
+        Log.UpgradingNuGetConfiguration(Logger);
+
+        var result = ProcessingResult.None;
+
+        foreach (var filePath in fileNames)
+        {
+            var name = RelativeName(filePath);
+
+            context.Status = StatusMessage($"Parsing {name}...");
+
+            (var project, var metadata) = await LoadProjectAsync(filePath, cancellationToken);
+
+            if (project is null || project.Root is null)
+            {
+                result = result.Max(ProcessingResult.Warning);
+                continue;
+            }
+
+            bool edited = false;
+
+            // <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
+            string major = upgrade.SdkVersion.Version.ToString(1);
+            string key = $"dotnet{major}";
+            string indexUrl = $"https://pkgs.dev.azure.com/dnceng/public/_packaging/{key}/nuget/v3/index.json";
+
+            if (project.Root.Name == "configuration" &&
+                project.Root.Elements("packageSources").FirstOrDefault() is { } packageSources)
+            {
+                var add = packageSources
+                    .Elements("add")
+                    .FirstOrDefault((p) => p.Attribute("key")?.Value == key);
+
+                if (add is null)
+                {
+                    add = new XElement("add", new XAttribute("key", key), new XAttribute("value", indexUrl));
+                    packageSources.Add(Spaces(2), add, NewLine(), Spaces(2));
+                    edited = true;
+                }
+            }
+
+            if (project.Root.Name == "configuration" &&
+                project.Root.Elements("packageSourceMapping").FirstOrDefault() is { } packageSourceMapping)
+            {
+                var packageSource = packageSourceMapping
+                    .Elements("packageSource")
+                    .FirstOrDefault((p) => p.Attribute("key")?.Value == key);
+
+                if (packageSource is null)
+                {
+                    packageSource = new XElement("packageSource", new XAttribute("key", key));
+
+                    packageSource.Add(
+                        NewLine(),
+                        Spaces(6),
+                        new XElement("package", new XAttribute("pattern", "*")),
+                        NewLine(),
+                        Spaces(4));
+
+                    packageSourceMapping.Add(Spaces(2), packageSource, NewLine(), Spaces(2));
+                    edited = true;
+                }
+            }
+
+            if (edited)
+            {
+                context.Status = StatusMessage($"Updating {name}...");
+
+                await UpdateProjectAsync(filePath, project, metadata, cancellationToken);
+
+                result = result.Max(ProcessingResult.Success);
+            }
+
+            static string Spaces(int count) => new(' ', count);
+            string NewLine() => metadata?.NewLine ?? Environment.NewLine;
+        }
+
+        if (result is ProcessingResult.Success)
+        {
+            logContext.Changelog.Add("Update NuGet configuration");
+        }
+
+        return result;
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Debug,
+            Message = "Upgrading NuGet configuration.")]
+        public static partial void UpgradingNuGetConfiguration(ILogger logger);
+    }
+}

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -225,7 +225,7 @@ internal sealed partial class PackageVersionUpgrader(
             arguments.AddRange(["--maximum-version", channel.ToString(2)]);
         }
 
-        if (Options.UpgradeType is UpgradeType.Preview)
+        if (Options.UpgradeType.IsPrerelease())
         {
             arguments.Add("--pre-release:Always");
 

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -260,14 +260,12 @@ internal sealed partial class PackageVersionUpgrader(
 
         foreach (string package in configuration.IncludeNuGetPackages)
         {
-            arguments.Add("--include");
-            arguments.Add(package);
+            arguments.Add($"--include:{package}");
         }
 
         foreach (string package in configuration.ExcludeNuGetPackages)
         {
-            arguments.Add("--exclude");
-            arguments.Add(package);
+            arguments.Add($"--exclude:{package}");
         }
 
         if (configuration.NoWarn.Count > 0)

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -30,8 +30,6 @@ internal sealed partial class PackageVersionUpgrader(
     /// </summary>
     private static readonly NuGetVersion MinimumVersionForMaximumVersion = new(4, 6, 5);
 
-    public override int Order => int.MaxValue - 1; // Packages need to be updated after the TFM so the packages relate to the update but before C# updates
-
     protected override string Action => "Upgrading NuGet packages";
 
     protected override string InitialStatus => "Upgrade NuGet packages";

--- a/src/DotNetBumper.Core/WellKnownFileNames.cs
+++ b/src/DotNetBumper.Core/WellKnownFileNames.cs
@@ -15,5 +15,6 @@ internal static class WellKnownFileNames
     public const string DirectoryBuildProps = "Directory.Build.props";
     public const string GitHubActionsWorkflowsDirectory = ".github/workflows";
     public const string GlobalJson = "global.json";
+    public const string NuGetConfiguration = "NuGet.config";
     public const string ToolsManifest = "dotnet-tools.json";
 }

--- a/src/DotNetBumper/Bumper.cs
+++ b/src/DotNetBumper/Bumper.cs
@@ -48,6 +48,11 @@ internal partial class Bumper(ProjectUpgrader upgrader)
     public bool NoLogo { get; set; }
 
     [Option(
+        "-ql|--quality <QUALITY>",
+        Description = "The type of quality to use for .NET daily builds.")]
+    public DotNetQuality? Quality { get; set; }
+
+    [Option(
         "-t|--upgrade-type <TYPE>",
         Description = "The type of upgrade to perform.")]
     public UpgradeType? UpgradeType { get; set; }

--- a/src/DotNetBumper/UpgradePostConfigureOptions.cs
+++ b/src/DotNetBumper/UpgradePostConfigureOptions.cs
@@ -27,6 +27,11 @@ internal sealed class UpgradePostConfigureOptions(IModelAccessor accessor) : IPo
             options.ProjectPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(command.ProjectPath));
         }
 
+        if (command.Quality is { } quality)
+        {
+            options.Quality = quality;
+        }
+
         if (command.UpgradeType is { } upgradeType)
         {
             options.UpgradeType = upgradeType;

--- a/tests/DotNetBumper.Tests/BumperConfigurationProviderTests.cs
+++ b/tests/DotNetBumper.Tests/BumperConfigurationProviderTests.cs
@@ -26,13 +26,15 @@ public class BumperConfigurationProviderTests(ITestOutputHelper outputHelper)
         actual.RemainingReferencesIgnore.ShouldBe([]);
     }
 
-    [Fact]
-    public async Task GetAsync_When_No_Custom_Configuration_For_Preview()
+    [Theory]
+    [InlineData(UpgradeType.Daily)]
+    [InlineData(UpgradeType.Preview)]
+    public async Task GetAsync_When_No_Custom_Configuration_For_Prerelease(UpgradeType upgradeType)
     {
         // Arrange
         using var fixture = new UpgraderFixture(outputHelper);
 
-        var target = CreateTarget(fixture, UpgradeType.Preview);
+        var target = CreateTarget(fixture, upgradeType);
 
         // Act
         var actual = await target.GetAsync(fixture.CancellationToken);
@@ -45,14 +47,16 @@ public class BumperConfigurationProviderTests(ITestOutputHelper outputHelper)
         actual.RemainingReferencesIgnore.ShouldBe([]);
     }
 
-    [Fact]
-    public async Task GetAsync_When_Json_Configuration()
+    [Theory]
+    [InlineData(UpgradeType.Daily)]
+    [InlineData(UpgradeType.Preview)]
+    public async Task GetAsync_When_Json_Configuration_For_Prerelease(UpgradeType upgradeType)
     {
         // Arrange
         using var fixture = new UpgraderFixture(outputHelper);
         await BumperConfigurationLoaderTests.CreateJsonConfigurationAsync(fixture);
 
-        var target = CreateTarget(fixture, UpgradeType.Preview);
+        var target = CreateTarget(fixture, upgradeType);
 
         // Act
         var actual = await target.GetAsync(fixture.CancellationToken);
@@ -65,14 +69,16 @@ public class BumperConfigurationProviderTests(ITestOutputHelper outputHelper)
         actual.RemainingReferencesIgnore.ShouldBe(["ignore-json-1", "ignore-json-2"]);
     }
 
-    [Fact]
-    public async Task GetAsync_When_Yaml_Configuration()
+    [Theory]
+    [InlineData(UpgradeType.Daily)]
+    [InlineData(UpgradeType.Preview)]
+    public async Task GetAsync_When_Yaml_Configuration(UpgradeType upgradeType)
     {
         // Arrange
         using var fixture = new UpgraderFixture(outputHelper);
         await BumperConfigurationLoaderTests.CreateYamlConfigurationAsync(fixture);
 
-        var target = CreateTarget(fixture, UpgradeType.Preview);
+        var target = CreateTarget(fixture, upgradeType);
 
         // Act
         var actual = await target.GetAsync(fixture.CancellationToken);

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -10,8 +10,9 @@ using Spectre.Console.Testing;
 namespace MartinCostello.DotNetBumper;
 
 [Collection("End-to-End")]
-public class EndToEndTests(ITestOutputHelper outputHelper)
+public sealed class EndToEndTests(ITestOutputHelper outputHelper) : IAsyncDisposable
 {
+    private static readonly string? _dotnetRoot = Environment.GetEnvironmentVariable(WellKnownEnvironmentVariables.DotNetRoot);
     private static bool? _dotnetHasPreview;
 
     [Fact]
@@ -70,6 +71,12 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
         }
 
         return testCases;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable(WellKnownEnvironmentVariables.DotNetRoot, _dotnetRoot);
+        return ValueTask.CompletedTask;
     }
 
     [Theory]

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -54,9 +54,12 @@ public sealed class EndToEndTests(ITestOutputHelper outputHelper) : IAsyncDispos
             ]);
         }
 
-        // TODO Work out if there's an active daily build (e.g. when .NET 11 development starts before .NET 10 is released)
-        // TODO Add a test case for upgrading from a daily build to another
-        testCases.Add(new BumperTestCase("9.0.100", ["net9.0"], ["--upgrade-type=daily"], Packages(("Microsoft.Extensions.Configuration.UserSecrets", "9.0.0"))));
+        // Skip daily build test in November and December when one release
+        // // has just finished and the next hasn't ramped up yet.
+        if (TimeProvider.System.GetUtcNow().Month is not (11 or 12))
+        {
+            testCases.Add(new BumperTestCase("9.0.100", ["net9.0"], ["--upgrade-type=daily"], Packages(("Microsoft.Extensions.Configuration.UserSecrets", "9.0.0"))));
+        }
 
         List<string> formats = ["Json", "Markdown"];
 

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -55,7 +55,7 @@ public sealed class EndToEndTests(ITestOutputHelper outputHelper) : IAsyncDispos
         }
 
         // Skip daily build test in November and December when one release
-        // // has just finished and the next hasn't ramped up yet.
+        // has just finished and the next hasn't ramped up yet.
         if (TimeProvider.System.GetUtcNow().Month is not (11 or 12))
         {
             testCases.Add(new BumperTestCase("9.0.100", ["net9.0"], ["--upgrade-type=daily"], Packages(("Microsoft.Extensions.Configuration.UserSecrets", "9.0.0"))));

--- a/tests/DotNetBumper.Tests/EndToEndTests.cs
+++ b/tests/DotNetBumper.Tests/EndToEndTests.cs
@@ -53,6 +53,10 @@ public class EndToEndTests(ITestOutputHelper outputHelper)
             ]);
         }
 
+        // TODO Work out if there's an active daily build (e.g. when .NET 11 development starts before .NET 10 is released)
+        // TODO Add a test case for upgrading from a daily build to another
+        testCases.Add(new BumperTestCase("9.0.100", ["net9.0"], ["--upgrade-type=daily"], Packages(("Microsoft.Extensions.Configuration.UserSecrets", "9.0.0"))));
+
         List<string> formats = ["Json", "Markdown"];
 
         if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is "true")

--- a/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
@@ -131,6 +131,7 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
     {
         var finder = new DotNetUpgradeFinder(
             new HttpClient(),
+            TimeProvider.System,
             Microsoft.Extensions.Options.Options.Create(new UpgradeOptions() { DotNetChannel = channel }),
             outputHelper.ToLogger<DotNetUpgradeFinder>());
 

--- a/tests/DotNetBumper.Tests/ProjectUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/ProjectUpgraderTests.cs
@@ -47,6 +47,7 @@ public class ProjectUpgraderTests(ITestOutputHelper outputHelper)
 
         var finder = new DotNetUpgradeFinder(
             new HttpClient(),
+            TimeProvider.System,
             options,
             outputHelper.ToLogger<DotNetUpgradeFinder>());
 

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -260,6 +260,7 @@ public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
         // Use the same SDK version as the upgrade to prevent a different dotnet format version being used
         var finder = new DotNetUpgradeFinder(
             new HttpClient(),
+            TimeProvider.System,
             Microsoft.Extensions.Options.Options.Create(new UpgradeOptions() { DotNetChannel = channel }),
             outputHelper.ToLogger<DotNetUpgradeFinder>());
 

--- a/tests/DotNetBumper.Tests/Upgraders/PackageVersionUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/PackageVersionUpgraderTests.cs
@@ -114,6 +114,7 @@ public class PackageVersionUpgraderTests(ITestOutputHelper outputHelper)
     {
         var finder = new DotNetUpgradeFinder(
             new HttpClient(),
+            TimeProvider.System,
             Microsoft.Extensions.Options.Options.Create(new UpgradeOptions() { DotNetChannel = channel }),
             outputHelper.ToLogger<DotNetUpgradeFinder>());
 


### PR DESCRIPTION
Add support for upgrading to the latest daily build of .NET.

### TODO

- [x] ~~Install the daily .NET SDK before running tasks as unlikely to be installed~~
- [x] ~~Handle additional NuGet feeds required for daily builds by adding/updating `NuGet.config`~~
- [x] ~~Improve error handling~~
- [x] ~~Integration and end-to-end tests~~
- [x] ~~Fix AoT warnings in Visual Studio~~
- [x] ~~Bump version to 0.10.0~~

Resolves #650.
