### PR TITLE
Fix CA1873 warnings

### DIFF
--- a/src/DotNetBumper.Core/BumperConfigurationProvider.cs
+++ b/src/DotNetBumper.Core/BumperConfigurationProvider.cs
@@ -53,6 +53,7 @@ internal sealed partial class BumperConfigurationProvider(
             configuration.RemainingReferencesIgnore.UnionWith(custom.RemainingReferencesIgnore);
         }
 
+#pragma warning disable CA1873
         if (logger.IsEnabled(LogLevel.Debug))
         {
             Log.IncludedNuGetPackages(logger, [.. configuration.IncludeNuGetPackages]);
@@ -60,6 +61,7 @@ internal sealed partial class BumperConfigurationProvider(
             Log.NoWarn(logger, [.. configuration.NoWarn]);
             Log.IgnoreRemainingReferences(logger, [.. configuration.RemainingReferencesIgnore]);
         }
+#pragma warning restore CA1873
 
         return configuration;
     }

--- a/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
+++ b/src/DotNetBumper.Core/DotNetUpgradeFinder.cs
@@ -272,8 +272,8 @@ public partial class DotNetUpgradeFinder(
 
         Log.FoundEligibleUpgrade(
             logger,
-            latestChannel.Channel.ToString(),
-            latestChannel.SdkVersion.ToFullString(),
+            latestChannel.Channel,
+            latestChannel.SdkVersion,
             latestChannel.ReleaseType);
 
         return latestChannel;
@@ -306,8 +306,8 @@ public partial class DotNetUpgradeFinder(
             Message = "Found eligible .NET upgrade. Channel: {Channel}, SDK Version: {SdkVersion}, Release Type: {ReleaseType}.")]
         public static partial void FoundEligibleUpgrade(
             ILogger logger,
-            string channel,
-            string sdkVersion,
+            Version channel,
+            NuGetVersion sdkVersion,
             DotNetReleaseType releaseType);
 
         [LoggerMessage(

--- a/src/DotNetBumper.Core/ProjectUpgrader.cs
+++ b/src/DotNetBumper.Core/ProjectUpgrader.cs
@@ -7,6 +7,7 @@ using MartinCostello.DotNetBumper.PostProcessors;
 using MartinCostello.DotNetBumper.Upgraders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using NuGet.Versioning;
 using Spectre.Console;
 
 namespace MartinCostello.DotNetBumper;
@@ -129,8 +130,8 @@ public partial class ProjectUpgrader(
             Log.Upgraded(
                 logger,
                 ProjectPath,
-                upgrade.Channel.ToString(),
-                upgrade.SdkVersion.ToString());
+                upgrade.Channel,
+                upgrade.SdkVersion);
 
             foreach (var processor in Order(postProcessors))
             {
@@ -288,8 +289,8 @@ public partial class ProjectUpgrader(
         public static partial void Upgraded(
             ILogger logger,
             string projectPath,
-            string channel,
-            string sdkVersion);
+            Version channel,
+            NuGetVersion sdkVersion);
 
         [LoggerMessage(
             EventId = 3,

--- a/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/DotNetCodeUpgrader.cs
@@ -115,9 +115,11 @@ internal sealed partial class DotNetCodeUpgrader(
         Dictionary<string, int> fixes = [];
         ProcessingResult result;
 
-        if (!string.IsNullOrWhiteSpace(formatResult.StandardError))
+        var errorsTrimmed = formatResult.StandardError.TrimEnd();
+
+        if (!string.IsNullOrWhiteSpace(errorsTrimmed))
         {
-            Log.DotNetFormatErrors(logger, formatResult.StandardError.TrimEnd());
+            Log.DotNetFormatErrors(logger, errorsTrimmed);
         }
 
         if (formatResult.Success)

--- a/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/GlobalJsonUpgrader.cs
@@ -63,8 +63,8 @@ internal sealed partial class GlobalJsonUpgrader(
                 Log.UpgradedDotNetSdk(
                     logger,
                     path,
-                    currentVersion.ToString(),
-                    upgrade.SdkVersion.ToString());
+                    currentVersion,
+                    upgrade.SdkVersion);
 
                 logContext.DotNetSdkVersion = upgrade.SdkVersion.ToString();
 
@@ -130,7 +130,7 @@ internal sealed partial class GlobalJsonUpgrader(
         public static partial void UpgradedDotNetSdk(
             ILogger logger,
             string fileName,
-            string previousVersion,
-            string upgradedVersion);
+            NuGetVersion previousVersion,
+            NuGetVersion upgradedVersion);
     }
 }


### PR DESCRIPTION
Fix CA1873 warnings raised by the .NET 10 preview 6 SDK.
