### PR TITLE
Simplify ReadLineAsync

### DIFF
--- a/src/DotNetBumper.Core/PowerShellScript.cs
+++ b/src/DotNetBumper.Core/PowerShellScript.cs
@@ -144,9 +144,8 @@ internal sealed class PowerShellScript
         using var reader = new StreamReader(input, metadata.Encoding);
 
         List<string> lines = [];
-        string? line;
 
-        while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
+        while (await reader.ReadLineAsync(cancellationToken) is { } line)
         {
             lines.Add(line);
         }

--- a/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/PackageVersionUpgrader.cs
@@ -101,9 +101,7 @@ internal sealed partial class PackageVersionUpgrader(
         {
             using var reader = new StringReader(result.StandardOutput);
 
-            string? line;
-
-            while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
+            while (await reader.ReadLineAsync(cancellationToken) is { } line)
             {
                 if (NuGetVersion.TryParse(line, out var version))
                 {


### PR DESCRIPTION
Simplify usage of `ReadLineAsync()`.
