### PR TITLE
Update Node.js v24

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -130,7 +130,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
-        node-version: '22'
+        node-version: '24'
 
     - name: Checkout ${{ format('{0}/{1}', github.repository_owner, matrix.repo) }}
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Update GitHub Actions workflows to use Node.js v24.
