### PR TITLE
Disable test parallelism

### DIFF
--- a/tests/DotNetBumper.Tests/xunit.runner.json
+++ b/tests/DotNetBumper.Tests/xunit.runner.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "methodDisplay": "method"
+  "methodDisplay": "method",
+  "parallelizeTestCollections": false
 }


### PR DESCRIPTION
Try to fix flaky tests on Linux by disabling parallelism.
