### PR TITLE
Remove workaround

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,6 @@
 <Project>
   <PropertyGroup>
     <AssemblyIsCLSCompliant>false</AssemblyIsCLSCompliant>
-    <!-- HACK Workaround for https://github.com/dotnet/sdk/issues/17454 -->
-    <BuildInParallel Condition="$([System.OperatingSystem]::IsWindows())">false</BuildInParallel>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)DotNetBumper.ruleset</CodeAnalysisRuleSet>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>


### PR DESCRIPTION
Remove workaround as it should be resolved in the latest .NET 9 and 10 SDKs.
