### PR TITLE
Selective parallelism opt-out

### DIFF
--- a/tests/DotNetBumper.Tests/NotInParallelCollection.cs
+++ b/tests/DotNetBumper.Tests/NotInParallelCollection.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper;
+
+[CollectionDefinition(nameof(NotInParallelCollection), DisableParallelization = true)]
+public sealed class NotInParallelCollection;

--- a/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
@@ -7,6 +7,7 @@ using NSubstitute;
 
 namespace MartinCostello.DotNetBumper.PostProcessors;
 
+[Collection<NotInParallelCollection>]
 public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
 {
     private static TimeSpan Timeout { get; } = TimeSpan.FromMinutes(4);

--- a/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/DotNetCodeUpgraderTests.cs
@@ -3,18 +3,12 @@
 
 namespace MartinCostello.DotNetBumper.Upgraders;
 
+[Collection<NotInParallelCollection>]
 public class DotNetCodeUpgraderTests(ITestOutputHelper outputHelper)
 {
     private static TimeSpan Timeout { get; } = TimeSpan.FromMinutes(4);
 
-    public static TheoryData<string> Channels()
-    {
-        return
-        [
-            "8.0",
-            "9.0",
-        ];
-    }
+    public static TheoryData<string> Channels() => ["8.0", "9.0"];
 
     [Theory]
     [MemberData(nameof(Channels))]

--- a/tests/DotNetBumper.Tests/xunit.runner.json
+++ b/tests/DotNetBumper.Tests/xunit.runner.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "methodDisplay": "method",
-  "parallelizeTestCollections": false
+  "methodDisplay": "method"
 }


### PR DESCRIPTION
Follow-up to #834 to make only _some_ tests not run in parallel, rather than _all_ of them.
