### PR TITLE
Disable dependabot-cooldown

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,7 @@
 rules:
   anonymous-definition:
     disable: true
+  dependabot-cooldown:
+    disable: true
   undocumented-permissions:
     disable: true


### PR DESCRIPTION
Disable the `dependabot-cooldown` rule.

Resolves https://github.com/martincostello/dotnet-bumper/security/code-scanning/254.
