### PR TITLE
Increase build timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     name: ${{ matrix.os-name }}
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}


### PR DESCRIPTION
Increase build timeout from 20 to 30 minutes after changes in #836 remove parallelism and slowed-down CI.
