### PR TITLE
Update RID data

### DIFF
--- a/src/DotNetBumper.Core/Resources/runtime-identifiers.portable.json
+++ b/src/DotNetBumper.Core/Resources/runtime-identifiers.portable.json
@@ -64,6 +64,23 @@
         "unix-x64"
       ]
     },
+    "openbsd": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "openbsd-arm64": {
+      "#import": [
+        "openbsd",
+        "unix-arm64"
+      ]
+    },
+    "openbsd-x64": {
+      "#import": [
+        "openbsd",
+        "unix-x64"
+      ]
+    },
     "haiku": {
       "#import": [
         "unix"
@@ -455,11 +472,6 @@
     "win": {
       "#import": [
         "any"
-      ]
-    },
-    "win-arm": {
-      "#import": [
-        "win"
       ]
     },
     "win-arm64": {

--- a/src/DotNetBumper.Core/RuntimeIdentifier.cs
+++ b/src/DotNetBumper.Core/RuntimeIdentifier.cs
@@ -12,12 +12,12 @@ namespace MartinCostello.DotNetBumper;
 internal sealed partial record RuntimeIdentifier(string Value)
 {
     /// <summary>
-    /// See https://github.com/dotnet/runtime/blob/49006967613007f58daab31abab5316999aa7897/src/libraries/Microsoft.NETCore.Platforms/src/PortableRuntimeIdentifierGraph.json.
+    /// See https://github.com/dotnet/runtime/blob/b77e008c4bd457ef29c4af17bfc99a7525949185/src/libraries/Microsoft.NETCore.Platforms/src/PortableRuntimeIdentifierGraph.json.
     /// </summary>
     private static readonly ImmutableDictionary<string, ImmutableHashSet<string>> PortableRids = LoadRuntimeIds("runtime-identifiers.portable");
 
     /// <summary>
-    /// See https://github.com/dotnet/runtime/blob/49006967613007f58daab31abab5316999aa7897/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json.
+    /// See https://github.com/dotnet/runtime/blob/b77e008c4bd457ef29c4af17bfc99a7525949185/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json.
     /// </summary>
     private static readonly ImmutableDictionary<string, ImmutableHashSet<string>> NonPortableRids = LoadRuntimeIds("runtime-identifiers");
 

--- a/tests/DotNetBumper.Tests/RuntimeIdentifierHelpersTests.cs
+++ b/tests/DotNetBumper.Tests/RuntimeIdentifierHelpersTests.cs
@@ -60,7 +60,7 @@ public static class RuntimeIdentifierHelpersTests
         foreach (var version in RuntimeIdentifierTests.WindowsVersions)
         {
             testCases.Add($"win{version}-aot", true, "win");
-            testCases.Add($"win{version}-arm", true, "win-arm");
+            testCases.Add($"win{version}-arm", true, "win");
             testCases.Add($"win{version}-arm64", true, "win-arm64");
             testCases.Add($"win{version}-x64", true, "win-x64");
             testCases.Add($"win{version}-x86", true, "win-x86");
@@ -114,7 +114,7 @@ public static class RuntimeIdentifierHelpersTests
         foreach (var version in RuntimeIdentifierTests.WindowsVersions)
         {
             testCases.Add($"bin\\Release\\win{version}-aot", true, "bin\\Release\\win");
-            testCases.Add($"bin\\Release\\win{version}-arm", true, "bin\\Release\\win-arm");
+            testCases.Add($"bin\\Release\\win{version}-arm", true, "bin\\Release\\win");
             testCases.Add($"bin\\Release\\win{version}-arm64", true, "bin\\Release\\win-arm64");
             testCases.Add($"bin\\Release\\win{version}-x64", true, "bin\\Release\\win-x64");
             testCases.Add($"bin\\Release\\win{version}-x86", true, "bin\\Release\\win-x86");


### PR DESCRIPTION
Update runtime identifier data.

Taken from https://github.com/dotnet/runtime/tree/b77e008c4bd457ef29c4af17bfc99a7525949185/src/libraries/Microsoft.NETCore.Platforms/src.
