### PR TITLE
Add support for Microsoft Testing Platform

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -80,18 +80,21 @@ jobs:
           - repo: alexa-london-travel-site
             upgrade-type: Latest
           - repo: alexa-london-travel-site
+            test: false
             upgrade-type: Preview
           - repo: apple-fitness-workout-mapper
             upgrade-type: Latest
           - repo: apple-fitness-workout-mapper
             upgrade-type: Preview
           - repo: costellobot
+            test: false
             upgrade-type: Latest
           - repo: costellobot
             upgrade-type: Preview
           - repo: dotnet-bumper
             upgrade-type: Latest
           - repo: dotnet-bumper
+            test: false
             upgrade-type: Preview
           - repo: dotnet-bumper-test
             upgrade-type: Latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,6 +14,7 @@ permissions: {}
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_GENERATE_ASPNET_CERTIFICATE: false
   DOTNET_NOLOGO: true
   DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
   FORCE_COLOR: 3
@@ -82,14 +83,15 @@ jobs:
           - repo: alexa-london-travel-site
             test: false
             upgrade-type: Preview
+            warnings-as-errors: false
           - repo: apple-fitness-workout-mapper
             upgrade-type: Latest
           - repo: apple-fitness-workout-mapper
             upgrade-type: Preview
           - repo: costellobot
-            test: false
             upgrade-type: Latest
           - repo: costellobot
+            test: false
             upgrade-type: Preview
           - repo: dotnet-bumper
             upgrade-type: Latest
@@ -114,8 +116,6 @@ jobs:
             upgrade-type: Latest
           - repo: website
             upgrade-type: Preview
-            test: true
-            warnings-as-errors: true
 
     steps:
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -111,6 +111,8 @@ jobs:
             upgrade-type: Latest
           - repo: website
             upgrade-type: Preview
+            test: true
+            warnings-as-errors: true
 
     steps:
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -75,30 +75,23 @@ jobs:
         include:
           - repo: alexa-london-travel
             upgrade-type: Latest
-            test: false
           - repo: alexa-london-travel
             upgrade-type: Preview
-            test: false
           - repo: alexa-london-travel-site
             upgrade-type: Latest
           - repo: alexa-london-travel-site
-            test: false
             upgrade-type: Preview
-            warnings-as-errors: false
           - repo: apple-fitness-workout-mapper
             upgrade-type: Latest
           - repo: apple-fitness-workout-mapper
-            test: false
             upgrade-type: Preview
           - repo: costellobot
             upgrade-type: Latest
           - repo: costellobot
-            test: false
             upgrade-type: Preview
           - repo: dotnet-bumper
             upgrade-type: Latest
           - repo: dotnet-bumper
-            test: false
             upgrade-type: Preview
           - repo: dotnet-bumper-test
             upgrade-type: Latest

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.3" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.6.0" />
     <PackageVersion Include="MSBuild.ProjectCreation" Version="18.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/src/DotNetBumper.Core/LogReader.cs
+++ b/src/DotNetBumper.Core/LogReader.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Text.Json;
+using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 
 namespace MartinCostello.DotNetBumper;
@@ -72,6 +73,130 @@ internal static partial class LogReader
         }
 
         return result;
+    }
+
+    public static async Task<BumperTestLog> GetTestLogsFromTrxAsync(
+        string path,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var result = new BumperTestLog();
+
+        try
+        {
+            foreach (var fileName in Directory.EnumerateFiles(path, "*.trx"))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    using var stream = File.OpenRead(fileName);
+                    var document = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken);
+
+                    ParseTrx(document, result);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Log.ReadTestLogsFailed(logger, ex);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.ReadTestLogsFailed(logger, ex);
+        }
+
+        return result;
+    }
+
+    private static void ParseTrx(XDocument document, BumperTestLog result)
+    {
+        // See https://learn.microsoft.com/visualstudio/test/test-result-trx-format
+        XNamespace ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+
+        var testRun = document.Root;
+
+        if (testRun is null)
+        {
+            return;
+        }
+
+        // Each TRX file is produced by a single test application (one per project and target
+        // framework), so derive a container name from the test assembly to keep the results distinct.
+        var container = testRun
+            .Element(ns + "TestDefinitions")?
+            .Elements(ns + "UnitTest")
+            .Select((p) => p.Attribute("storage")?.Value)
+            .FirstOrDefault((p) => !string.IsNullOrEmpty(p));
+
+        container = string.IsNullOrEmpty(container) ? "Default" : Path.GetFileNameWithoutExtension(container);
+
+        var results = testRun.Element(ns + "Results");
+
+        if (results is not null)
+        {
+            var outcomes = new List<BumperTestLogEntry>();
+
+            foreach (var unitTestResult in results.Elements(ns + "UnitTestResult"))
+            {
+                outcomes.Add(new()
+                {
+                    Id = unitTestResult.Attribute("testName")?.Value,
+                    Outcome = MapOutcome(unitTestResult.Attribute("outcome")?.Value),
+                    ErrorMessage = unitTestResult
+                        .Element(ns + "Output")?
+                        .Element(ns + "ErrorInfo")?
+                        .Element(ns + "Message")?.Value,
+                });
+            }
+
+            if (outcomes.Count > 0)
+            {
+                result.Outcomes[container] =
+                    result.Outcomes.TryGetValue(container, out var existing) ?
+                    [.. existing, .. outcomes] :
+                    outcomes;
+            }
+        }
+
+        var counters = testRun.Element(ns + "ResultSummary")?.Element(ns + "Counters");
+
+        if (counters is not null)
+        {
+            var summary = new Dictionary<string, long>()
+            {
+                ["Passed"] = GetCount(counters, "passed"),
+                ["Skipped"] = GetCount(counters, "notExecuted") + GetCount(counters, "inconclusive"),
+                ["Failed"] = GetCount(counters, "failed") +
+                             GetCount(counters, "error") +
+                             GetCount(counters, "timeout") +
+                             GetCount(counters, "aborted"),
+            };
+
+            if (result.Summary.TryGetValue(container, out var existing))
+            {
+                foreach ((var outcome, var count) in summary)
+                {
+                    existing.TryGetValue(outcome, out var current);
+                    existing[outcome] = current + count;
+                }
+            }
+            else
+            {
+                result.Summary[container] = summary;
+            }
+        }
+
+        static long GetCount(XElement counters, string name)
+            => long.TryParse(counters.Attribute(name)?.Value, out var value) ? value : 0;
+
+        static string MapOutcome(string? outcome) => outcome switch
+        {
+            "Passed" => "Passed",
+            "NotExecuted" or "Inconclusive" => "Skipped",
+            null or "" => "None",
+            _ => "Failed",
+        };
     }
 
     private static async Task<T> DeserializeAsync<T>(string path, Action<Exception> onException, CancellationToken cancellationToken)

--- a/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
+++ b/src/DotNetBumper.Core/PostProcessors/DotNetTestPostProcessor.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using MartinCostello.DotNetBumper.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -132,6 +134,55 @@ internal sealed partial class DotNetTestPostProcessor(
         }
     }
 
+    private static bool UsesMicrosoftTestingPlatformRunner(string projectDirectory)
+    {
+        var globalJson = FileHelpers.FindFileInProject(projectDirectory, WellKnownFileNames.GlobalJson);
+
+        if (globalJson is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (JsonHelpers.TryLoadObject(globalJson, out var root) &&
+                root.TryGetPropertyValue("test", out var test) &&
+                test is JsonObject testObject &&
+                testObject.TryGetPropertyValue("runner", out var runner) &&
+                runner is JsonValue value &&
+                value.GetValueKind() is JsonValueKind.String &&
+                string.Equals(value.GetValue<string>(), "Microsoft.Testing.Platform", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        catch (Exception)
+        {
+            // Ignore malformed global.json file
+        }
+
+        return false;
+    }
+
+    private static List<string> ResolveProjectFiles(string projectDirectory)
+    {
+        var projectFiles = new List<string>();
+
+        foreach (var file in ProjectHelpers.FindProjectFiles(projectDirectory, SearchOption.TopDirectoryOnly))
+        {
+            if (Path.GetExtension(file) is ".sln" or ".slnx")
+            {
+                projectFiles.AddRange(ProjectHelpers.GetSolutionProjects(file));
+            }
+            else
+            {
+                projectFiles.Add(file);
+            }
+        }
+
+        return projectFiles;
+    }
+
     private async Task<DotNetResult> RunTestsAsync(
         List<string> projects,
         NuGetVersion sdkVersion,
@@ -182,12 +233,8 @@ internal sealed partial class DotNetTestPostProcessor(
         BumperConfiguration configuration,
         CancellationToken cancellationToken)
     {
-        using var adapterDirectory = GetTestAdapter();
-        using var logsDirectory = new TemporaryDirectory();
-
         var environmentVariables = new Dictionary<string, string?>()
         {
-            [BumperTestLogger.LoggerDirectoryPathVariableName] = logsDirectory.Path,
             [WellKnownEnvironmentVariables.NuGetAudit] = "false",
         };
 
@@ -210,6 +257,33 @@ internal sealed partial class DotNetTestPostProcessor(
             environmentVariables[WellKnownEnvironmentVariables.DirectoryBuildPropertiesPath] = propertiesOverrides.Path;
         }
 
+        try
+        {
+            // The custom VSTest logger cannot be used with Microsoft Testing Platform (MTP),
+            // so when MTP is in use the tests are run differently and the results captured from
+            // a TRX report instead (if the relevant extension is available to the project).
+            var platform = await DetectTestPlatformAsync(project, cancellationToken);
+
+            return platform is TestPlatform.MicrosoftTestingPlatform
+                ? await RunTestsWithTestingPlatformAsync(project, environmentVariables, cancellationToken)
+                : await RunTestsWithVSTestAsync(project, environmentVariables, cancellationToken);
+        }
+        finally
+        {
+            propertiesOverrides?.Dispose();
+        }
+    }
+
+    private async Task<DotNetResult> RunTestsWithVSTestAsync(
+        string project,
+        Dictionary<string, string?> environmentVariables,
+        CancellationToken cancellationToken)
+    {
+        using var adapterDirectory = GetTestAdapter();
+        using var logsDirectory = new TemporaryDirectory();
+
+        environmentVariables[BumperTestLogger.LoggerDirectoryPathVariableName] = logsDirectory.Path;
+
         string[] arguments =
         [
             "test",
@@ -224,25 +298,200 @@ internal sealed partial class DotNetTestPostProcessor(
             Logger.GetMSBuildVerbosity(),
         ];
 
-        DotNetResult result;
-
-        try
-        {
-            // See https://learn.microsoft.com/dotnet/core/tools/dotnet-test
-            result = await dotnet.RunWithLoggerAsync(
-                project,
-                arguments,
-                environmentVariables,
-                cancellationToken);
-        }
-        finally
-        {
-            propertiesOverrides?.Dispose();
-        }
+        // See https://learn.microsoft.com/dotnet/core/tools/dotnet-test
+        var result = await dotnet.RunWithLoggerAsync(
+            project,
+            arguments,
+            environmentVariables,
+            cancellationToken);
 
         result.TestLogs = await LogReader.GetTestLogsAsync(logsDirectory.Path, Logger, cancellationToken);
 
         return result;
+    }
+
+    private async Task<DotNetResult> RunTestsWithTestingPlatformAsync(
+        string project,
+        Dictionary<string, string?> environmentVariables,
+        CancellationToken cancellationToken)
+    {
+        // The custom MSBuild logger used to capture build errors and warnings cannot be passed to
+        // "dotnet test" when Microsoft Testing Platform is in use, so build the project separately
+        // first (which the logger does support) and then run the already-built tests.
+        // See https://learn.microsoft.com/dotnet/core/testing/unit-testing-with-dotnet-test.
+        string[] buildArguments =
+        [
+            "build",
+            "--configuration",
+            "Release",
+            "--verbosity",
+            Logger.GetMSBuildVerbosity(),
+        ];
+
+        var buildResult = await dotnet.RunWithLoggerAsync(
+            project,
+            buildArguments,
+            environmentVariables,
+            cancellationToken);
+
+        if (!buildResult.Success)
+        {
+            return buildResult;
+        }
+
+        // Unlike VSTest, "dotnet test" with Microsoft Testing Platform fails if it is run for a
+        // project that is not a test project (such as an application project), so there is nothing
+        // more to do in that case as the test projects that reference it have now been built too.
+        // This is determined after the build so that the relevant MSBuild properties are available.
+        if (!await IsTestProjectAsync(project, cancellationToken))
+        {
+            return buildResult;
+        }
+
+        bool supportsTrx = await SupportsTrxReportAsync(project, cancellationToken);
+
+        using var resultsDirectory = new TemporaryDirectory();
+
+        List<string> testArguments =
+        [
+            "test",
+            "--no-build",
+            "--configuration",
+            "Release",
+        ];
+
+        if (supportsTrx)
+        {
+            // The results directory is an argument to "dotnet test" itself, whereas arguments after
+            // "--" are forwarded to the test application, which produces a TRX report in that
+            // directory which the test results are then read from.
+            testArguments.Add("--results-directory");
+            testArguments.Add(resultsDirectory.Path);
+            testArguments.Add("--");
+            testArguments.Add("--report-trx");
+        }
+
+        var result = await dotnet.RunAsync(
+            project,
+            testArguments,
+            environmentVariables,
+            cancellationToken);
+
+        result.BuildLogs = buildResult.BuildLogs;
+
+        if (supportsTrx)
+        {
+            result.TestLogs = await LogReader.GetTestLogsFromTrxAsync(resultsDirectory.Path, Logger, cancellationToken);
+        }
+
+        return result;
+    }
+
+    private async Task<TestPlatform> DetectTestPlatformAsync(
+        string projectDirectory,
+        CancellationToken cancellationToken)
+    {
+        if (UsesMicrosoftTestingPlatformRunner(projectDirectory))
+        {
+            return TestPlatform.MicrosoftTestingPlatform;
+        }
+
+        foreach (var projectFile in ResolveProjectFiles(projectDirectory))
+        {
+            var value = await EvaluateMSBuildPropertyAsync(
+                projectFile,
+                "TestingPlatformDotnetTestSupport",
+                cancellationToken);
+
+            if (string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase))
+            {
+                return TestPlatform.MicrosoftTestingPlatform;
+            }
+        }
+
+        return TestPlatform.VSTest;
+    }
+
+    private async Task<bool> IsTestProjectAsync(
+        string projectDirectory,
+        CancellationToken cancellationToken)
+    {
+        foreach (var projectFile in ResolveProjectFiles(projectDirectory))
+        {
+            var isTestProject = await EvaluateMSBuildPropertyAsync(projectFile, "IsTestProject", cancellationToken);
+            var isTestingPlatformApplication = await EvaluateMSBuildPropertyAsync(projectFile, "IsTestingPlatformApplication", cancellationToken);
+
+            if (string.Equals(isTestProject, bool.TrueString, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(isTestingPlatformApplication, bool.TrueString, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<bool> SupportsTrxReportAsync(
+        string projectDirectory,
+        CancellationToken cancellationToken)
+    {
+        const string TrxReportPackage = "Microsoft.Testing.Extensions.TrxReport";
+
+        foreach (var projectFile in ResolveProjectFiles(projectDirectory))
+        {
+            var packages = await EvaluateMSBuildItemsAsync(projectFile, "PackageReference", cancellationToken);
+
+            if (packages.Any((p) => string.Equals(p, TrxReportPackage, StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<IReadOnlyList<string>> EvaluateMSBuildItemsAsync(
+        string projectFile,
+        string itemType,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var getItem = await dotnet.RunAsync(
+                Options.ProjectPath,
+                ["msbuild", projectFile, $"-getItem:{itemType}"],
+                cancellationToken);
+
+            if (getItem.Success && !string.IsNullOrWhiteSpace(getItem.StandardOutput))
+            {
+                using var document = JsonDocument.Parse(getItem.StandardOutput);
+
+                if (document.RootElement.TryGetProperty("Items", out var items) &&
+                    items.TryGetProperty(itemType, out var values) &&
+                    values.ValueKind is JsonValueKind.Array)
+                {
+                    var identities = new List<string>(values.GetArrayLength());
+
+                    foreach (var value in values.EnumerateArray())
+                    {
+                        if (value.TryGetProperty("Identity", out var identity) &&
+                            identity.ValueKind is JsonValueKind.String &&
+                            identity.GetString() is { Length: > 0 } id)
+                        {
+                            identities.Add(id);
+                        }
+                    }
+
+                    return identities;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.FailedToEvaluateItems(Logger, itemType, projectFile, ex);
+        }
+
+        return [];
     }
 
     private async Task<TemporaryFile> GenerateDirectoryBuildPropsAsync(
@@ -450,5 +699,11 @@ internal sealed partial class DotNetTestPostProcessor(
             Level = LogLevel.Debug,
             Message = "Test {Container}.{Id} failed: {ErrorMessage}")]
         public static partial void TestFailed(ILogger logger, string container, string? id, string? errorMessage);
+
+        [LoggerMessage(
+            EventId = 3,
+            Level = LogLevel.Debug,
+            Message = "Failed to evaluate the {ItemType} MSBuild items from {ProjectFile}.")]
+        public static partial void FailedToEvaluateItems(ILogger logger, string itemType, string projectFile, Exception exception);
     }
 }

--- a/src/DotNetBumper.Core/PostProcessors/TestPlatform.cs
+++ b/src/DotNetBumper.Core/PostProcessors/TestPlatform.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DotNetBumper.PostProcessors;
+
+/// <summary>
+/// An enumeration of the test platforms that a project's tests can be run with.
+/// </summary>
+internal enum TestPlatform
+{
+    /// <summary>
+    /// VSTest.
+    /// </summary>
+    VSTest = 0,
+
+    /// <summary>
+    /// Microsoft Testing Platform (MTP).
+    /// </summary>
+    MicrosoftTestingPlatform,
+}

--- a/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
+++ b/src/DotNetBumper.Core/ServiceCollectionExtensions.cs
@@ -77,6 +77,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IUpgrader, DotNetCodeUpgrader>();
         services.AddSingleton<IUpgrader, GitHubActionsUpgrader>();
         services.AddSingleton<IUpgrader, GlobalJsonUpgrader>();
+        services.AddSingleton<IUpgrader, MicrosoftTestingPlatformUpgrader>();
         services.AddSingleton<IUpgrader, NuGetConfigUpgrader>();
         services.AddSingleton<IUpgrader, PackageVersionUpgrader>();
         services.AddSingleton<IUpgrader, PowerShellScriptUpgrader>();

--- a/src/DotNetBumper.Core/Upgraders/MicrosoftTestingPlatformUpgrader.cs
+++ b/src/DotNetBumper.Core/Upgraders/MicrosoftTestingPlatformUpgrader.cs
@@ -1,0 +1,237 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Xml.Linq;
+using MartinCostello.DotNetBumper.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Spectre.Console;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+/// <summary>
+/// An upgrader that migrates projects using Microsoft Testing Platform through the legacy
+/// VSTest mode of <c>dotnet test</c> to the dedicated Microsoft Testing Platform mode. This
+/// is required because running tests via the VSTest target is not supported by Microsoft
+/// Testing Platform when using the .NET 10 SDK or later.
+/// See <c>https://learn.microsoft.com/dotnet/core/testing/unit-testing-with-dotnet-test</c>.
+/// </summary>
+internal sealed partial class MicrosoftTestingPlatformUpgrader(
+    IAnsiConsole console,
+    IEnvironment environment,
+    BumperLogContext logContext,
+    IOptions<UpgradeOptions> options,
+    ILogger<MicrosoftTestingPlatformUpgrader> logger) : XmlFileUpgrader(console, environment, options, logger)
+{
+    private const string RunnerName = "Microsoft.Testing.Platform";
+    private const string VSTestSupportProperty = "TestingPlatformDotnetTestSupport";
+
+    private static readonly string[] ObsoleteProperties =
+    [
+        VSTestSupportProperty,
+        "TestingPlatformCaptureOutput",
+        "TestingPlatformShowTestsFailure",
+    ];
+
+    protected override string Action => "Migrating to Microsoft Testing Platform";
+
+    protected override string InitialStatus => "Migrate test platform";
+
+    protected override IReadOnlyList<string> Patterns { get; } =
+    [
+        WellKnownFileNames.DirectoryBuildProps,
+        WellKnownFileNames.CSharpProjects,
+        WellKnownFileNames.FSharpProjects,
+        WellKnownFileNames.VisualBasicProjects,
+    ];
+
+    protected override async Task<ProcessingResult> UpgradeCoreAsync(
+        UpgradeInfo upgrade,
+        IReadOnlyList<string> fileNames,
+        StatusContext context,
+        CancellationToken cancellationToken)
+    {
+        var projects = new List<(string Path, XDocument Document, FileMetadata? Metadata)>(fileNames.Count);
+        bool usesVSTestMode = false;
+
+        foreach (var filePath in fileNames)
+        {
+            var name = RelativeName(filePath);
+            context.Status = StatusMessage($"Parsing {name}...");
+
+            (var project, var metadata) = await LoadProjectAsync(filePath, cancellationToken);
+
+            if (project?.Root is null)
+            {
+                continue;
+            }
+
+            projects.Add((filePath, project, metadata));
+
+            if (UsesVSTestMode(project.Root))
+            {
+                usesVSTestMode = true;
+            }
+        }
+
+        if (!usesVSTestMode)
+        {
+            // The project(s) do not use Microsoft Testing Platform through the legacy
+            // VSTest mode of "dotnet test", so there is nothing that needs to be migrated.
+            return ProcessingResult.None;
+        }
+
+        Log.MigratingTestPlatform(Logger);
+
+        var result = ProcessingResult.None;
+
+        foreach ((var filePath, var project, var metadata) in projects)
+        {
+            if (TryRemoveObsoleteProperties(project.Root!))
+            {
+                context.Status = StatusMessage($"Updating {RelativeName(filePath)}...");
+
+                await UpdateProjectAsync(filePath, project, metadata, cancellationToken);
+
+                result = result.Max(ProcessingResult.Success);
+            }
+        }
+
+        result = result.Max(await EnableTestingPlatformRunnerAsync(upgrade, context, cancellationToken));
+
+        if (result is ProcessingResult.Success)
+        {
+            logContext.Changelog.Add("Migrate test projects to use Microsoft Testing Platform");
+        }
+
+        return result;
+    }
+
+    private static bool UsesVSTestMode(XElement project)
+    {
+        foreach (var property in ProjectHelpers.EnumerateProperties(project))
+        {
+            if (string.Equals(property.Name.LocalName, VSTestSupportProperty, StringComparison.OrdinalIgnoreCase) &&
+                bool.TryParse(property.Value, out var enabled) &&
+                enabled)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryRemoveObsoleteProperties(XElement project)
+    {
+        var properties = ProjectHelpers.EnumerateProperties(project)
+            .Where((p) => ObsoleteProperties.Any((name) => string.Equals(p.Name.LocalName, name, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        foreach (var property in properties)
+        {
+            // Also remove the whitespace preceding the property to avoid leaving a blank line behind.
+            if (property.PreviousNode is XText text && string.IsNullOrWhiteSpace(text.Value))
+            {
+                text.Remove();
+            }
+
+            property.Remove();
+        }
+
+        return properties.Count > 0;
+    }
+
+    private static bool TryEnableRunner(JsonObject root)
+    {
+        if (root["test"] is not JsonObject test)
+        {
+            test = [];
+            root["test"] = test;
+        }
+
+        if (test["runner"] is JsonValue runner &&
+            runner.GetValueKind() is JsonValueKind.String &&
+            string.Equals(runner.GetValue<string>(), RunnerName, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        test["runner"] = RunnerName;
+        return true;
+    }
+
+    private async Task<ProcessingResult> EnableTestingPlatformRunnerAsync(
+        UpgradeInfo upgrade,
+        StatusContext context,
+        CancellationToken cancellationToken)
+    {
+        var globalJsonFiles = Directory.GetFiles(Options.ProjectPath, WellKnownFileNames.GlobalJson, SearchOption.AllDirectories);
+
+        if (globalJsonFiles.Length is 0)
+        {
+            // A global.json file is required to opt in to the Microsoft Testing Platform mode of
+            // "dotnet test", so create one configured to use the runner if none already exists.
+            var path = Path.Combine(Options.ProjectPath, WellKnownFileNames.GlobalJson);
+
+            context.Status = StatusMessage($"Creating {RelativeName(path)}...");
+
+            var globalJson = new JsonObject()
+            {
+                ["sdk"] = new JsonObject() { ["version"] = upgrade.SdkVersion.ToString() },
+                ["test"] = new JsonObject() { ["runner"] = RunnerName },
+            };
+
+            // The file does not exist yet, so it cannot be saved using JsonExtensions.SaveAsync()
+            // as that reads the metadata of the existing file to preserve its encoding.
+            var json = globalJson.ToJsonString(new() { WriteIndented = true });
+            await File.WriteAllTextAsync(path, json + Environment.NewLine, cancellationToken);
+
+            return ProcessingResult.Success;
+        }
+
+        var result = ProcessingResult.None;
+
+        foreach (var path in globalJsonFiles)
+        {
+            JsonObject? root;
+
+            try
+            {
+                if (!JsonHelpers.TryLoadObject(path, out root))
+                {
+                    result = result.Max(ProcessingResult.Warning);
+                    continue;
+                }
+            }
+            catch (JsonException)
+            {
+                result = result.Max(ProcessingResult.Warning);
+                continue;
+            }
+
+            if (TryEnableRunner(root))
+            {
+                context.Status = StatusMessage($"Updating {RelativeName(path)}...");
+
+                await root.SaveAsync(path, cancellationToken);
+
+                result = result.Max(ProcessingResult.Success);
+            }
+        }
+
+        return result;
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 1,
+            Level = LogLevel.Debug,
+            Message = "Migrating test projects to use Microsoft Testing Platform.")]
+        public static partial void MigratingTestPlatform(ILogger logger);
+    }
+}

--- a/tests/DotNetBumper.Tests/LogReaderTests.cs
+++ b/tests/DotNetBumper.Tests/LogReaderTests.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MartinCostello.DotNetBumper;
+
+public class LogReaderTests
+{
+    [Fact]
+    public async Task GetTestLogsFromTrxAsync_Reads_Outcomes_And_Summary()
+    {
+        // Arrange
+        using var directory = new TemporaryDirectory();
+
+        const string Trx =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <TestRun xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+              <Results>
+                <UnitTestResult testName="Project.Tests.PassingTest" outcome="Passed" />
+                <UnitTestResult testName="Project.Tests.SkippedTest" outcome="NotExecuted" />
+                <UnitTestResult testName="Project.Tests.FailingTest" outcome="Failed">
+                  <Output>
+                    <ErrorInfo>
+                      <Message>Expected true but was false.</Message>
+                    </ErrorInfo>
+                  </Output>
+                </UnitTestResult>
+              </Results>
+              <TestDefinitions>
+                <UnitTest name="Project.Tests.PassingTest" storage="/code/tests/project.tests.dll" />
+              </TestDefinitions>
+              <ResultSummary outcome="Failed">
+                <Counters total="3" executed="2" passed="1" failed="1" notExecuted="1" />
+              </ResultSummary>
+            </TestRun>
+            """;
+
+        await File.WriteAllTextAsync(Path.Combine(directory.Path, "results.trx"), Trx, TestContext.Current.CancellationToken);
+
+        // Act
+        var actual = await LogReader.GetTestLogsFromTrxAsync(
+            directory.Path,
+            NullLogger.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        actual.ShouldNotBeNull();
+
+        const string Container = "project.tests";
+
+        actual.Outcomes.ShouldContainKey(Container);
+        actual.Outcomes[Container].Count.ShouldBe(3);
+
+        var failure = actual.Outcomes[Container].Where((p) => p.Outcome is "Failed").ShouldHaveSingleItem();
+        failure.Id.ShouldBe("Project.Tests.FailingTest");
+        failure.ErrorMessage.ShouldBe("Expected true but was false.");
+
+        actual.Summary.ShouldContainKey(Container);
+        var summary = actual.Summary[Container];
+        summary["Passed"].ShouldBe(1);
+        summary["Failed"].ShouldBe(1);
+        summary["Skipped"].ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetTestLogsFromTrxAsync_Returns_Empty_When_No_Files()
+    {
+        // Arrange
+        using var directory = new TemporaryDirectory();
+
+        // Act
+        var actual = await LogReader.GetTestLogsFromTrxAsync(
+            directory.Path,
+            NullLogger.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.Outcomes.ShouldBeEmpty();
+        actual.Summary.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetTestLogsFromTrxAsync_Ignores_Malformed_Trx()
+    {
+        // Arrange
+        using var directory = new TemporaryDirectory();
+
+        await File.WriteAllTextAsync(Path.Combine(directory.Path, "broken.trx"), "<not-valid", TestContext.Current.CancellationToken);
+
+        // Act
+        var actual = await LogReader.GetTestLogsFromTrxAsync(
+            directory.Path,
+            NullLogger.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.Outcomes.ShouldBeEmpty();
+        actual.Summary.ShouldBeEmpty();
+    }
+}

--- a/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
+++ b/tests/DotNetBumper.Tests/PostProcessors/DotNetTestPostProcessorTests.cs
@@ -129,6 +129,48 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
         actual.ShouldBe(ProcessingResult.Success);
     }
 
+    [Fact]
+    public async Task PostProcessAsync_Succeeds_For_Microsoft_Testing_Platform_With_Trx_Report()
+    {
+        // Arrange
+        var upgrade = await GetUpgradeAsync("10.0");
+
+        using var fixture = await CreateFixtureAsync(upgrade, useMtp: true, useTrxReport: true);
+
+        var target = CreateTarget(fixture);
+
+        using var cts = new CancellationTokenSource(Timeout);
+
+        // Act
+        var actual = await target.PostProcessAsync(upgrade, cts.Token);
+
+        // Assert
+        actual.ShouldBe(ProcessingResult.Success);
+
+        // The results should have been read from the TRX report
+        fixture.LogContext.TestLogs.ShouldNotBeNull();
+        fixture.LogContext.TestLogs.Summary.Values.Sum((p) => p.Values.Sum()).ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task PostProcessAsync_Succeeds_For_Microsoft_Testing_Platform_Without_Trx_Report()
+    {
+        // Arrange
+        var upgrade = await GetUpgradeAsync("10.0");
+
+        using var fixture = await CreateFixtureAsync(upgrade, useMtp: true);
+
+        var target = CreateTarget(fixture);
+
+        using var cts = new CancellationTokenSource(Timeout);
+
+        // Act
+        var actual = await target.PostProcessAsync(upgrade, cts.Token);
+
+        // Assert - success is determined by the exit code when no TRX report is available
+        actual.ShouldBe(ProcessingResult.Success);
+    }
+
     private static DotNetTestPostProcessor CreateTarget(
         UpgraderFixture fixture,
         IOptions<UpgradeOptions>? options = null)
@@ -177,7 +219,10 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
         return upgrade;
     }
 
-    private async Task<UpgraderFixture> CreateFixtureAsync(UpgradeInfo upgrade)
+    private async Task<UpgraderFixture> CreateFixtureAsync(
+        UpgradeInfo upgrade,
+        bool useMtp = false,
+        bool useTrxReport = false)
     {
         var fixture = new UpgraderFixture(outputHelper);
 
@@ -188,9 +233,13 @@ public class DotNetTestPostProcessorTests(ITestOutputHelper outputHelper)
             await fixture.Project.AddGitIgnoreAsync();
 
             await fixture.Project.AddApplicationProjectAsync(targetFrameworks);
-            await fixture.Project.AddGlobalJsonAsync(upgrade.SdkVersion.ToString());
+            await fixture.Project.AddGlobalJsonAsync(upgrade.SdkVersion.ToString(), useMtp: useMtp);
 
-            await fixture.Project.AddTestProjectAsync(targetFrameworks);
+            await fixture.Project.AddTestProjectAsync(
+                targetFrameworks,
+                useMtp: useMtp,
+                useTrxReport: useTrxReport);
+
             await fixture.Project.AddUnitTestsAsync();
 
             return fixture;

--- a/tests/DotNetBumper.Tests/Project.cs
+++ b/tests/DotNetBumper.Tests/Project.cs
@@ -61,9 +61,9 @@ internal sealed class Project : IDisposable
         Directory.CreateDirectory(Path.Combine(DirectoryName, ".git"));
     }
 
-    public async Task<string> AddGlobalJsonAsync(string sdkVersion, string path = "global.json")
+    public async Task<string> AddGlobalJsonAsync(string sdkVersion, string path = "global.json", bool useMtp = false)
     {
-        var globalJson = CreateGlobalJson(sdkVersion);
+        var globalJson = CreateGlobalJson(sdkVersion, useMtp);
         return await AddFileAsync(path, globalJson);
     }
 
@@ -80,7 +80,9 @@ internal sealed class Project : IDisposable
         ICollection<KeyValuePair<string, string>>? packageReferences = default,
         ICollection<string>? projectReferences = default,
         string path = "tests/Project.Tests/Project.Tests.csproj",
-        ICollection<KeyValuePair<string, string>>? properties = default)
+        ICollection<KeyValuePair<string, string>>? properties = default,
+        bool useMtp = false,
+        bool useTrxReport = false)
     {
         packageReferences ??= [];
 
@@ -91,12 +93,18 @@ internal sealed class Project : IDisposable
             KeyValuePair.Create("OutputType", "Exe"),
         ];
 
-        string[] testPackages =
+        // "xunit.v3.mtp-off" uses VSTest, whereas "xunit.v3.mtp-v2" uses Microsoft Testing Platform.
+        List<string> testPackages =
         [
             "Microsoft.NET.Test.Sdk",
             "xunit.runner.visualstudio",
-            "xunit.v3.mtp-off",
+            useMtp ? "xunit.v3.mtp-v2" : "xunit.v3.mtp-off",
         ];
+
+        if (useTrxReport)
+        {
+            testPackages.Add("Microsoft.Testing.Extensions.TrxReport");
+        }
 
         foreach (var id in testPackages.Where((p) => packageReferences is null || !packageReferences.Any((r) => r.Key == p)))
         {

--- a/tests/DotNetBumper.Tests/Upgraders/MicrosoftTestingPlatformUpgraderTests.cs
+++ b/tests/DotNetBumper.Tests/Upgraders/MicrosoftTestingPlatformUpgraderTests.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace MartinCostello.DotNetBumper.Upgraders;
+
+public class MicrosoftTestingPlatformUpgraderTests(ITestOutputHelper outputHelper)
+{
+    private const string Changelog = "Migrate test projects to use Microsoft Testing Platform";
+
+    private static UpgradeInfo Upgrade => new()
+    {
+        Channel = Version.Parse("10.0"),
+        EndOfLife = DateOnly.MaxValue,
+        ReleaseType = DotNetReleaseType.Lts,
+        SdkVersion = new("10.0.100"),
+        SupportPhase = DotNetSupportPhase.Active,
+    };
+
+    [Fact]
+    public async Task UpgradeAsync_Migrates_VSTest_Mode_Project_And_Updates_Global_Json()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string project =
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+                <TestingPlatformCaptureOutput>false</TestingPlatformCaptureOutput>
+                <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+              </PropertyGroup>
+            </Project>
+            """;
+
+        string projectPath = await fixture.Project.AddFileAsync("tests/Project.Tests/Project.Tests.csproj", project);
+        string globalJsonPath = await fixture.Project.AddGlobalJsonAsync("10.0.100");
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.UpgradeAsync(Upgrade, fixture.CancellationToken);
+
+        // Assert
+        actual.ShouldBe(ProcessingResult.Success);
+        fixture.LogContext.Changelog.ShouldContain(Changelog);
+
+        string updatedProject = await File.ReadAllTextAsync(projectPath, fixture.CancellationToken);
+        updatedProject.ShouldNotContain("TestingPlatformDotnetTestSupport");
+        updatedProject.ShouldNotContain("TestingPlatformCaptureOutput");
+        updatedProject.ShouldNotContain("TestingPlatformShowTestsFailure");
+
+        await AssertRunnerEnabledAsync(globalJsonPath, fixture.CancellationToken);
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_Creates_Global_Json_When_None_Exists()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string project =
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+              </PropertyGroup>
+            </Project>
+            """;
+
+        await fixture.Project.AddFileAsync("tests/Project.Tests/Project.Tests.csproj", project);
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.UpgradeAsync(Upgrade, fixture.CancellationToken);
+
+        // Assert
+        actual.ShouldBe(ProcessingResult.Success);
+        fixture.LogContext.Changelog.ShouldContain(Changelog);
+
+        string globalJsonPath = fixture.Project.GetFilePath("global.json");
+        File.Exists(globalJsonPath).ShouldBeTrue();
+
+        var runner = await AssertRunnerEnabledAsync(globalJsonPath, fixture.CancellationToken);
+        runner.RootElement.GetProperty("sdk").GetProperty("version").GetString().ShouldBe("10.0.100");
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_Does_Nothing_When_Not_Using_VSTest_Mode()
+    {
+        // Arrange
+        using var fixture = new UpgraderFixture(outputHelper);
+
+        string project =
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+              </PropertyGroup>
+            </Project>
+            """;
+
+        await fixture.Project.AddFileAsync("tests/Project.Tests/Project.Tests.csproj", project);
+        string globalJsonPath = await fixture.Project.AddGlobalJsonAsync("10.0.100");
+
+        var target = CreateTarget(fixture);
+
+        // Act
+        var actual = await target.UpgradeAsync(Upgrade, fixture.CancellationToken);
+
+        // Assert
+        actual.ShouldBe(ProcessingResult.None);
+        fixture.LogContext.Changelog.ShouldNotContain(Changelog);
+
+        string globalJson = await File.ReadAllTextAsync(globalJsonPath, fixture.CancellationToken);
+        globalJson.ShouldNotContain("runner");
+    }
+
+    private static async Task<JsonDocument> AssertRunnerEnabledAsync(string globalJsonPath, CancellationToken cancellationToken)
+    {
+        string globalJson = await File.ReadAllTextAsync(globalJsonPath, cancellationToken);
+
+        var document = JsonDocument.Parse(globalJson);
+
+        document.RootElement
+            .GetProperty("test")
+            .GetProperty("runner")
+            .GetString()
+            .ShouldBe("Microsoft.Testing.Platform");
+
+        return document;
+    }
+
+    private static MicrosoftTestingPlatformUpgrader CreateTarget(UpgraderFixture fixture)
+    {
+        return new(
+            fixture.Console,
+            fixture.Environment,
+            fixture.LogContext,
+            fixture.CreateOptions(),
+            fixture.CreateLogger<MicrosoftTestingPlatformUpgrader>());
+    }
+}


### PR DESCRIPTION
Add support for handling projects using Microsoft Testing Platform and migrating projects to use it.

Resolves #1111.
